### PR TITLE
fix: saved account compared wrongly

### DIFF
--- a/contexts/wallet/index.js
+++ b/contexts/wallet/index.js
@@ -76,7 +76,7 @@ export const WalletProvider = ({ children }) => {
   const [isWalletReady, setIsWalletReady] = useState(false);
   const isCorrectNetwork = BLOCKCHAIN_NETWORK_ID === chainId;
   const hasSameConnectedAccount =
-    user?.walletAddress.toLowerCase() === account.toLowerCase();
+    user?.walletAddress?.toLowerCase() === account?.toLowerCase();
 
   useEffect(() => {
     setIsWalletReady(

--- a/contexts/wallet/index.js
+++ b/contexts/wallet/index.js
@@ -75,9 +75,8 @@ export const WalletProvider = ({ children }) => {
 
   const [isWalletReady, setIsWalletReady] = useState(false);
   const isCorrectNetwork = BLOCKCHAIN_NETWORK_ID === chainId;
-  const hasSameConnectedAccount = user?.walletAddress
-    ? account.toLowerCase() === user?.walletAddress.toLowerCase()
-    : true;
+  const hasSameConnectedAccount =
+    user?.walletAddress.toLowerCase() === account.toLowerCase();
 
   useEffect(() => {
     setIsWalletReady(

--- a/contexts/wallet/index.js
+++ b/contexts/wallet/index.js
@@ -76,7 +76,7 @@ export const WalletProvider = ({ children }) => {
   const [isWalletReady, setIsWalletReady] = useState(false);
   const isCorrectNetwork = BLOCKCHAIN_NETWORK_ID === chainId;
   const hasSameConnectedAccount = user?.walletAddress
-    ? account === user?.walletAddress
+    ? account.toLowerCase() === user?.walletAddress.toLowerCase()
     : true;
 
   useEffect(() => {
@@ -160,7 +160,6 @@ export const WalletProvider = ({ children }) => {
     );
     if (!user?.walletAddress) {
       const activated = await injected.activate();
-      console.log('linking user.walletAddress =', activated?.account);
       await linkWalletWithUser(activated?.account);
     }
   };


### PR DESCRIPTION
We need to compare `user.walletAddress` and current (used in browser) wallet address only after lower-casing them. Otherwise they don't match