### PR TITLE
fix: make profile without image also have a link to profile page

### DIFF
--- a/components/ConnectedWallet.js
+++ b/components/ConnectedWallet.js
@@ -9,7 +9,7 @@ const ConnectedWallet = () => {
     try {
       await api.post('/auth/web3/unlink');
     } catch (e) {
-      console.log('error on disconnecting the wallet', e);
+      console.error('error on disconnecting the wallet', e);
     }
   };
 

--- a/components/Profile.js
+++ b/components/Profile.js
@@ -11,23 +11,23 @@ const Profile = () => {
   return (
     <div className="w-full">
       <div className="flex justify-center items-center w-24 h-24 absolute left-0 right-0 mx-auto -translate-y-1/2 z-20">
-        {user.photo ? (
-          <Link href={`/members/${user?.slug}`} passsHref>
-            <a
-              title="View profile"
-              className="md:flex md:flex-row items-center cursor-pointer"
-            >
+        <Link href={`/members/${user?.slug}`} passsHref>
+          <a
+            title="View profile"
+            className="md:flex md:flex-row items-center cursor-pointer"
+          >
+            {user.photo ? (
               <img
                 src={`${cdn}${user.photo}-profile-lg.jpg`}
                 loading="lazy"
                 alt={user.screenname}
                 className="w-32 md:w-44 rounded-full"
               />
-            </a>
-          </Link>
-        ) : (
-          <FaUser className="text-gray-200 text-6xl" />
-        )}
+            ) : (
+              <FaUser className="text-gray-200 text-6xl" />
+            )}
+          </a>
+        </Link>
       </div>
 
       <div className="pt-14 px-4 pb-8 shadow-xl relative rounded-lg w-full">

--- a/pages/members/[slug].js
+++ b/pages/members/[slug].js
@@ -310,9 +310,7 @@ const MemberPage = ({ member }) => {
                     </button>
                   )}
                 </div>
-                <div className="">
-                  <ConnectedWallet />
-                </div>
+                <ConnectedWallet />
                 <div className="flex flex-col items-start md:w-6/12">
                   <div className="w-full">
                     <div className="page-title flex justify-between">


### PR DESCRIPTION
clicking on profile without image should be possible
<img width="379" alt="Screenshot 2023-02-01 at 22 58 59" src="https://user-images.githubusercontent.com/4914235/216185217-62260c4a-11be-4e77-b1ed-6721f993b484.png">
