### PR TITLE
feat: save token sale data to spreadsheet

### DIFF
--- a/packages/closer/pages/token/checkout.tsx
+++ b/packages/closer/pages/token/checkout.tsx
@@ -62,12 +62,6 @@ const TokenSaleCheckoutPage = ({ generalConfig }: Props) => {
   }, [isAuthenticated, isLoading]);
 
   useEffect(() => {
-    if (!isWalletReady) {
-      router.push('/token/before-you-begin');
-    }
-  }, []);
-
-  useEffect(() => {
     isWalletReady &&
       (async () => {
         const totalCost = await getTotalCost(tokens as string);
@@ -105,6 +99,14 @@ const TokenSaleCheckoutPage = ({ generalConfig }: Props) => {
     const { success, txHash, error } = await buyTokens(tokens as string);
     if (success) {
       try {
+        await api.post('/accounting/token-sales-log', {
+          txHash,
+          unitPrice,
+          tokens,
+          total,
+          userId: user?._id,
+        });
+
         await api.post('/metric', {
           event: 'token-sale',
           value: Number(tokens),


### PR DESCRIPTION
Added new api route call to log token sale data.

works with BE: https://github.com/closerdao/closer-api/pull/181

Closes #425

