### PR TITLE
Feat allow multiple space booking

### DIFF
--- a/apps/tdf/cypress/e2e/booking.cy.js
+++ b/apps/tdf/cypress/e2e/booking.cy.js
@@ -62,7 +62,7 @@ const fillStripeForm = () => {
   getIframeBody().find('input[name="cardnumber"]').type('4242424242424242');
   getIframeBody().find('input[name="exp-date"]').type('1035');
   getIframeBody().find('input[name="cvc"]').type('111');
-  getIframeBody().find('input[name="postal"]').type('90210');
+  // getIframeBody().find('input[name="postal"]').type('90210');
 };
 
 describe('Booking flow', () => {
@@ -338,7 +338,7 @@ describe('Booking flow', () => {
   });
 });
 
-it.only('should have correct authenticated overnight event booking flow', () => {
+it('should have correct authenticated overnight event booking flow', () => {
   cy.visit(`${Cypress.config('baseUrl')}/login`);
   login({ isAdmin: true });
 

--- a/packages/closer/components/ListingCard.js
+++ b/packages/closer/components/ListingCard.js
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import PropTypes from 'prop-types';
 
+import { CloserCurrencies } from '../types';
 import { cdn } from '../utils/api';
 import ListingPrice from './ListingPrice';
 import Button from './ui/Button';
@@ -17,16 +18,14 @@ const ListingCard = ({
   useTokens,
   bookingType,
   isAuthenticated,
-  adults,
 }) => {
   const t = useTranslations();
   const router = useRouter();
-  const { name, description, rentalFiat, rentalToken, utilityFiat, available } =
+  const { name, description, rentalToken, utilityFiat, available } =
     listing;
 
   const [firstPHtml, setFirstPHtml] = useState('');
 
-  // const firstParagraphHTML = extractFirstParagraph(description);
 
   useEffect(() => {
     const extractFirstParagraph = (html) => {
@@ -84,7 +83,9 @@ const ListingCard = ({
       </ul>
       <div className="my-8">
         <ListingPrice
-          rentalFiat={rentalFiat}
+          rentalFiat={
+            listing?.fiatPrice || { val: 0, cur: CloserCurrencies.EUR }
+          }
           rentalToken={rentalToken}
           utilityFiat={utilityFiat}
           useTokens={useTokens}
@@ -92,16 +93,11 @@ const ListingCard = ({
         />
       </div>
 
-      {adults > listing.beds && listing.private && (
-        <div className="my-6 font-bold">
-          {name} {t('listing_preview_max_beds', { var: listing.beds })}{' '}
-        </div>
-      )}
       <Button
         onClick={handleBooking}
         type="secondary"
         isEnabled={
-          available !== false && !(listing.private && adults > listing.beds)
+          available !== false 
         }
       >
         {available !== false

--- a/packages/closer/components/SpaceHostBooking/index.tsx
+++ b/packages/closer/components/SpaceHostBooking/index.tsx
@@ -44,7 +44,8 @@ const SpaceHostBooking = ({ listingOptions }: Props) => {
     }
     if (isCalendarSelectionValid) {
       (async function updatePrices() {
-        const { results } = await getAvailability(start, end, listingId);
+        const { results, availability } = await getAvailability(start, end, listingId);
+ 
         setIsListingAvailable(Boolean(results));
       })();
     }
@@ -62,6 +63,7 @@ const SpaceHostBooking = ({ listingOptions }: Props) => {
         start: formatDate(startDate),
         end: formatDate(endDate),
         listing: listingId,
+        adults,
       });
 
       return { results, availability };

--- a/packages/closer/components/SummaryDates.tsx
+++ b/packages/closer/components/SummaryDates.tsx
@@ -53,6 +53,7 @@ interface SummaryDatesProps {
   workingHoursStart?: number | undefined;
   workingHoursEnd?: number | undefined;
   listingId?: string | undefined;
+  numSpacesRequired?: number;
 }
 
 const SummaryDates = ({
@@ -75,11 +76,11 @@ const SummaryDates = ({
   setters,
   updatedListingId,
   listings,
-  updatedMaxBeds,
   priceDuration,
   workingHoursStart,
   workingHoursEnd,
   listingId,
+  numSpacesRequired,
 }: SummaryDatesProps) => {
   const t = useTranslations();
 
@@ -96,15 +97,14 @@ const SummaryDates = ({
   let listingOptions: { value: string; label: string }[] | null =
     listings?.map((listing) => ({ value: listing._id, label: listing.name })) ||
     null;
-  
-    if (priceDuration === 'hour') {
-      listingOptions =
-        listings
-          ?.filter((listing) => listing.priceDuration === 'hour')
-          .map((listing) => ({ value: listing._id, label: listing.name })) ||
-        null;
-    }
-  
+
+  if (priceDuration === 'hour') {
+    listingOptions =
+      listings
+        ?.filter((listing) => listing.priceDuration === 'hour')
+        .map((listing) => ({ value: listing._id, label: listing.name })) ||
+      null;
+  }
 
   const durationInDays = dayjs(endDate)
     .startOf('day')
@@ -347,7 +347,7 @@ const SummaryDates = ({
               href={`/stay/${listingUrl}`}
               className="font-bold uppercase text-right text-accent"
             >
-              {listingName}
+              {listingName} {numSpacesRequired && 'x' + ' ' + numSpacesRequired}
             </Link>
           )}
         </div>

--- a/packages/closer/components/SummaryDates.tsx
+++ b/packages/closer/components/SummaryDates.tsx
@@ -202,7 +202,6 @@ const SummaryDates = ({
                     value={totalGuests}
                     setFn={setters?.setUpdatedAdults}
                     minValue={1}
-                    maxValue={updatedMaxBeds}
                   />
                 </div>
               ) : (

--- a/packages/closer/pages/bookings/[slug]/summary.tsx
+++ b/packages/closer/pages/bookings/[slug]/summary.tsx
@@ -178,6 +178,7 @@ const Summary = ({
             eventName={event?.name}
             ticketOption={ticketOption?.name}
             priceDuration={listing?.priceDuration}
+            numSpacesRequired={listing?.private ? Math.ceil(booking.adults / (listing?.beds || 1)) : booking.adults}
           />
           <SummaryCosts
             utilityFiat={utilityFiat}

--- a/packages/closer/pages/bookings/create/dates.tsx
+++ b/packages/closer/pages/bookings/create/dates.tsx
@@ -127,8 +127,12 @@ const DatesSelector = ({
     }
   }, []);
 
-  const [start, setStartDate] = useState<string | null | Date>();
-  const [end, setEndDate] = useState<string | null | Date>();
+  const [start, setStartDate] = useState<string | null | Date>(
+    (savedStartDate as string) || null,
+  );
+  const [end, setEndDate] = useState<string | null | Date>(
+    (savedEndDate as string) || null,
+  );
   const [adults, setAdults] = useState<number>(Number(savedAdults) || 1);
   const [kids, setKids] = useState<number>(Number(savedKids) || 0);
   const [infants, setInfants] = useState<number>(Number(savedInfants) || 0);
@@ -149,9 +153,10 @@ const DatesSelector = ({
     eventId && (!ticketOptions?.length || selectedTicketOption),
   );
   const hasVolunteerId = volunteerId;
-  const hasValidDates = (start && end) || (savedStartDate && savedEndDate);
+  const hasValidDates =
+    Boolean(start && end) || Boolean(savedStartDate && savedEndDate);
   const isGeneralCase =
-    !eventId && !volunteerId && start && end && !bookingError;
+    !eventId && !volunteerId && hasValidDates && !bookingError;
   const startDate = dayjs(start).startOf('day');
   const endDate = dayjs(end).startOf('day');
   const diffInDays = endDate.diff(startDate, 'day');

--- a/packages/closer/pages/stay/[slug]/index.tsx
+++ b/packages/closer/pages/stay/[slug]/index.tsx
@@ -302,7 +302,7 @@ const ListingPage: NextPage<Props> = ({
             (min: number, day: { numSpacesAvailable: number }) =>
               Math.min(min, day.numSpacesAvailable),
             Infinity,
-          );
+          ) || 0;
           setNumSpacesAvailable(minNumSpacesAvailable);
         }
         setIsListingAvailable(results);

--- a/packages/closer/types/booking.ts
+++ b/packages/closer/types/booking.ts
@@ -205,3 +205,12 @@ export type FoodPriceParams = {
   eventId: string | undefined;
   bookingConfig: BookingConfig | undefined | null;
 };
+
+export type UpdatedPrices = {
+  rentalFiat: Price<CloserCurrencies.EUR>;
+  rentalToken: Price<CloserCurrencies.TDF>;
+  eventFiat: Price<CloserCurrencies.EUR>;
+  foodFiat: Price<CloserCurrencies.EUR>;
+  utilityFiat: Price<CloserCurrencies.EUR>;
+  total: Price<CloserCurrencies.EUR>;
+};


### PR DESCRIPTION
Allowing to book multiple spaces in a single booking - both shared and private.

Closes #551

Also closes point 6 of #519 

Works with BE: https://github.com/closerdao/closer-api/pull/193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced booking flow with updated availability tracking and pricing calculations.
	- Added a new state variable for tracking available spaces in listings.
	- Introduced a new type definition for managing updated pricing information.

- **Bug Fixes**
	- Adjusted end-to-end tests for booking flow to improve reliability.

- **Refactor**
	- Streamlined pricing calculations by relying on API calls instead of synchronous calculations.
	- Modified the `SpaceHostBooking` component to include additional parameters in API requests.
	- Updated date selection logic to retain previously saved selections.
	- Simplified the `ListingCard` component by removing unnecessary complexity related to guest counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->