### PR TITLE
feat: check in process

### DIFF
--- a/packages/closer/components/BookingListPreview/BookingListPreview.tsx
+++ b/packages/closer/components/BookingListPreview/BookingListPreview.tsx
@@ -14,7 +14,7 @@ import {
 import { priceFormat } from '../../utils/helpers';
 import BookingRequestButtons from '../BookingRequestButtons';
 import UserInfoButton from '../UserInfoButton';
-import { Card, LinkButton } from '../ui';
+import { Button, Card, LinkButton } from '../ui';
 
 interface Props {
   booking: any;
@@ -70,6 +70,12 @@ const BookingListPreview = ({
   const router = useRouter();
 
   const { platform }: any = usePlatform();
+
+  const isPaidBooking =
+    status === 'paid' ||
+    status === 'credits-paid' ||
+    status === 'tokens-staked';
+
   const flagPickup =
     doesNeedPickup && start > new Date(Date.now() - 12 * 60 * 60 * 1000);
   const startFormatted = dayjs(start).format('DD/MM/YYYY');
@@ -79,7 +85,9 @@ const BookingListPreview = ({
   const isNotPaid =
     status !== 'paid' &&
     status !== 'tokens-staked' &&
-    status !== 'credits-paid';
+    status !== 'credits-paid' &&
+    status !== 'checked-in' &&
+    status !== 'checked-out';
 
   const bookingType = getBookingType(eventId, volunteerId);
 
@@ -88,6 +96,12 @@ const BookingListPreview = ({
   };
   const rejectBooking = async () => {
     await platform.bookings.reject(_id);
+  };
+  const checkInBooking = async () => {
+    await platform.bookings.checkIn(_id);
+  };
+  const checkOutBooking = async () => {
+    await platform.bookings.checkOut(_id);
   };
 
   const getStatusText = (status: string, updated: string | Date) => {
@@ -290,6 +304,20 @@ const BookingListPreview = ({
           {t('booking_card_email_user')}
         </LinkButton>
       )}
+
+      {isPaidBooking &&
+        new Date(bookingMapItem.get('end')) > new Date() &&
+        status !== 'checked-in' && (
+          <Button className="mt-6" type="secondary" onClick={checkInBooking}>
+            ➡️ {t('booking_card_checkin')}
+          </Button>
+        )}
+      {status === 'checked-in' &&
+         (
+          <Button className="mt-6" type="secondary" onClick={checkOutBooking}>
+            ⬅️ {t('booking_card_checkout')}
+          </Button>
+        )}
 
       <BookingRequestButtons
         _id={_id}

--- a/packages/closer/components/BookingRequestButtons/index.tsx
+++ b/packages/closer/components/BookingRequestButtons/index.tsx
@@ -42,7 +42,8 @@ const BookingRequestButtons = ({
       {/* Hide buttons if start date is in the past: */}
       {new Date(start) > new Date() && (
         <>
-          {status === 'checked-in' && (
+          {/* TODO: add links for checked in and checked out guests */}
+          {/* {status === 'checked-in' && (
             <Link passHref href="">
               <Button type="secondary">
                 {t('booking_card_join_chat_button')}
@@ -55,7 +56,7 @@ const BookingRequestButtons = ({
                 {t('booking_card_feedback_button')}
               </Button>
             </Link>
-          )}
+          )} */}
           {status === 'open' && (
             <Link passHref href={`/bookings/${_id}/summary`}>
               <Button type="secondary">

--- a/packages/closer/contexts/platform/platform.js
+++ b/packages/closer/contexts/platform/platform.js
@@ -528,6 +528,30 @@ export const PlatformProvider = ({ children }) => {
         dispatch(action);
         return action;
       }),
+    checkIn: (_id) =>
+      api.post(`/bookings/${_id}/check-in`).then((res) => {
+        const results = fromJS(res.data.results);
+        const action = {
+          results,
+          _id,
+          model: 'booking',
+          type: constants.PATCH_SUCCESS,
+        };
+        dispatch(action);
+        return action;
+      }),
+    checkOut: (_id) =>
+      api.post(`/bookings/${_id}/check-out`).then((res) => {
+        const results = fromJS(res.data.results);
+        const action = {
+          results,
+          _id,
+          model: 'booking',
+          type: constants.PATCH_SUCCESS,
+        };
+        dispatch(action);
+        return action;
+      }),
   };
 
   platform.carrots = {

--- a/packages/closer/pages/bookings/[slug]/index.tsx
+++ b/packages/closer/pages/bookings/[slug]/index.tsx
@@ -170,7 +170,9 @@ const BookingPage = ({
   const isNotPaid =
     status !== 'paid' &&
     status !== 'credits-paid' &&
-    status !== 'tokens-staked';
+    status !== 'tokens-staked' &&
+    status !== 'checked-in' &&
+    status !== 'checked-out';
 
   let updatedDuration = 0;
 


### PR DESCRIPTION
Allowing to check in and check out. Space hosts can check in and check out guests. Guests can check themselves out.

Closes #392 

Works with BE: https://github.com/closerdao/closer-api/pull/196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced check-in and check-out buttons in the booking preview based on booking status.
  - Enhanced booking status checks to include 'checked-in' and 'checked-out' for payment evaluations.
  - Added methods to handle check-in and check-out actions within the platform's booking functionality.

- **Bug Fixes**
  - Refined booking duration calculations for hourly and daily bookings.

- **Chores**
  - Temporarily disabled rendering of buttons for 'checked-in' and 'checked-out' statuses in the booking request buttons component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->