### PR TITLE
Add last day cancelation policy

### DIFF
--- a/packages/closer/components/Conditions.tsx
+++ b/packages/closer/components/Conditions.tsx
@@ -105,6 +105,7 @@ const Conditions = ({
               {t('booking_cancelation_policy', {
                 lastweek: `${(cancellationPolicy?.lastweek || 1) * 100}%`,
                 lastmonth: `${(cancellationPolicy?.lastmonth || 1) * 100}%`,
+                lastday: `${(cancellationPolicy?.lastday || 1) * 100}%`,
               })}
             </p>
           </div>

--- a/packages/closer/locales/base-en.json
+++ b/packages/closer/locales/base-en.json
@@ -40,7 +40,7 @@
   "bookings_payment_utility": "Payment Food Cost",
   "booking_cancelation_policy_member": "Members can cancel their bookings at no cost, up to 7 days before check in. If you cancel within less than 7 days, you'll receive a 50% refund.",
   "booking_volunteering_details": "You will be supporting the efforts of the stewards on the ground by providing 3-4h of work each day.",
-  "booking_cancelation_policy": "In case the booking is declined for any reason you will receive a full refund. If you decide to cancel, you will receive a {lastmonth} refund up to 30 days prior and {lastweek} refund up to 7 days before the booking.",
+  "booking_cancelation_policy": "In case the booking is declined for any reason you will receive a full refund. If you decide to cancel, you will receive a {lastmonth} refund up to 30 days prior, {lastweek} refund up to 7 days before the booking, and {lastday} refund up until the last day.",
   "booking_cancel_button": "Cancel booking",
   "booking_confirm_button": "Approve",
   "booking_reject_button": "Reject",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the cancellation policy modal to display an additional refund condition for cancellations made on the last day before the booking.
- **Documentation**
  - Enhanced the cancellation policy text to clearly state refund options for cancellations up to 30 days, 7 days, and the last day before the booking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->