### PR TITLE
Plan Village App deployment config inventory

### DIFF
--- a/docs/village-app-deployment-config-inventory.md
+++ b/docs/village-app-deployment-config-inventory.md
@@ -128,6 +128,8 @@ Prebuild fetches backend `/config` → writes `packages/closer/generated/appConf
 - `general` snapshot — seeds identity, locale, currency, timezone, footer, page metadata
 - `booking` snapshot — split booking policy from homepage content before coding
 
+**Which API the prebuild fetches from.** The prebuild reads `CONFIG_BUILD_API_URL` if set, falling back to `NEXT_PUBLIC_API_URL` (#942). Provisioned villages set it to the DigitalOcean ingress, because at build time the branded API domain may not resolve yet (closer-procurement#546). The fetch retries with backoff and **fails the build** if the API answers with an error — a village never ships a silently stale snapshot. Two paths still degrade quietly and matter for row decisions: neither URL set at all skips the fetch and keeps whatever snapshot the build started with, and a missing snapshot file is bootstrapped to `{}`, leaving pages on schema defaults.
+
 ---
 
 ## 7 — 🎛️ Runtime DB config

--- a/docs/village-app-deployment-config-inventory.md
+++ b/docs/village-app-deployment-config-inventory.md
@@ -8,7 +8,9 @@ Five homes:
 
 > This is a **review**, not a build plan. Nothing gets coded until it reads `accepted`.
 
-> ⚖️ **Open decision, not a settled goal:** whether we should be able to *spin up a new village without touching env vars* is **still a discussion** — not something this deck assumes or commits to. Env vars stay in play until that discussion lands.
+> ✅ **Rows closed 2026-08-04.** Every `proposed` / `needs discussion` row in this deck was decided in one pass (owner: Avi). Decisions are recorded inline below; the reasoning lives in the config-revisit map. Where a decision commits to build work, that work is filed as repo issues rather than described here — this deck stays a map of *where config lives*, not a plan of what to write.
+
+> ⚖️ **Zero-env-edit spin-up: decided — yes, for standard villages.** A village on the MVP path (commerce gates off) provisions with **no human editing env**. Provisioning already enforces this: `assembleVillageEnv` is the single assembly path and `validateDeployEnvWrite` rejects writes outside the village-owned rows. **One named exception:** Stripe Connect — `createStripeAccount` is a deliberately blocked provider, so a village turning on money features takes a manual Stripe onboarding step. Any *new* manual env row needs a reason recorded here; "it was easier" is how a village ends up inheriting another village's identity.
 
 ---
 
@@ -48,8 +50,10 @@ Reference apps are **sources to learn from**, not things we migrate.
 | Status | Means |
 | --- | --- |
 | `accepted` | Agreed. Move on unless new evidence. |
-| `proposed` | Probably right. Needs a look. |
-| `needs discussion` | **Do not code yet.** |
+| `accepted*` | Agreed **for now**, with a named revisit trigger in the notes. |
+| `platform` | Not village config. Owned by the platform/deployment; outside this deck's remit — see §4a. |
+| ~~`proposed`~~ | Retired 2026-08-04 — every row was decided. |
+| ~~`needs discussion`~~ | Retired 2026-08-04 — every row was decided. |
 
 | Flag | Means |
 | --- | --- |
@@ -69,6 +73,28 @@ Reference apps are **sources to learn from**, not things we migrate.
 - Feature availability has **two switches — both must be on:**
   - **env gate** (`NEXT_PUBLIC_FEATURE_*`) — compiled per deployment. If not `true`, the code path is dead: route 404s, nav item hidden. This is the *capability* switch, read from `process.env` at build/server time.
   - **DB config** — per-village `enabled` flag (e.g. `fundraiser.enabled`). This is the *per-village* switch.
+  - **Status: `accepted*` — env gates stay for MVP; revisit after launch.** Moving the gates to DB is attractive (an operator toggle that needs a redeploy is the same complaint #915 fixed for booking config, and env-held flags sit awkwardly against the zero-env-edit rule above) — but a DB flag read from the *build snapshot* is equally frozen, so the move only pays off combined with live runtime reads, and it turns dead routes into reachable-but-hidden ones. Not an MVP-path problem. Filed for post-launch.
+- **Content / identity / structure** — the seam for anything that renders:
+  - **content** (page bodies, FAQs, informational pages, public documents, hero and content images) → **CMS**
+  - **identity** (village name, canonical URL, logo, contact, socials, OG defaults) → **`general`** DB config
+  - **structure** (routes, layout shell, flows, product mechanics) → **code**
+  - Applies to new content types too — the point is to stop re-arguing each one.
+- **Neutral by default.** No schema default may carry another village's value. A village that seeds *nothing* must still render as itself, not as TDF. Seeding explicit empty strings is a workaround, not the mechanism — the defaults themselves must be neutral, and "absent bucket ⇒ neutral" is the acceptance test.
+
+---
+
+## 4a — 🏗️ Platform-owned, not village config
+
+Some values are deployment or build-pipeline plumbing. They are **out of this deck's remit** — they are not pending review, and the config catalog should not mark them as awaiting a deck row.
+
+| Value | Why it is not village config |
+| --- | --- |
+| `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN` | Deployment observability |
+| `NEXT_PUBLIC_LOG_REQUESTS` | Debug switch (single read, `packages/closer/utils/api.js:351`) |
+| `CONFIG_BUILD_API_URL` | Build-script input; deliberately outside the village env contract |
+| `NEXT_PUBLIC_CLOUDFLARE_KEY` | Read by `packages/closer`, not the village env shape (ADR 0017) |
+
+The catalog still owns and drift-checks these rows — they simply stop pretending to await deck review. `notInDeck` previously conflated "unreviewed" with "not our business", and because that status **locks a row out of form editing**, the conflation had teeth.
 
 ---
 
@@ -82,32 +108,35 @@ Keep these in env vars unless review finds a strong reason to move them.
 | --- | --- | --- | --- | --- | --- | --- |
 | `NEXT_PUBLIC_API_URL` | village + refs | env | ✗ | ✓ | ✓ | accepted |
 | `NEXT_PUBLIC_PLATFORM_URL` | village + refs | env | ✗ | ✓ | ✓ | accepted |
-| `NEXT_PUBLIC_PLATFORM` | refs | env | ✗ | ✗ | ✗ | proposed |
-| `NEXT_PUBLIC_CDN_URL` | village + refs | env | ✗ | ✗ | maybe | proposed |
-| `NEXT_PUBLIC_LOG_REQUESTS` | refs | env | ✗ | ✗ | ✗ | proposed |
-| `NEXT_PUBLIC_NETWORK` | refs | env | ✗ | web3 | web3 | proposed |
+| `NEXT_PUBLIC_PLATFORM` | refs | **delete** | ✗ | ✗ | ✗ | accepted |
+| `NEXT_PUBLIC_APP_NAME` | village | env, **required** | ✗ | ✓ | ✓ | accepted |
+| `NEXT_PUBLIC_PLATFORM_NAME` | village | **delete** → `general.platformName` | ✗ | ✗ | ✗ | accepted |
+| `NEXT_PUBLIC_CDN_URL` | village + refs | env | ✗ | ✗ | maybe | accepted |
+| `NEXT_PUBLIC_NETWORK` | refs | env | ✗ | web3 | web3 | accepted* |
 | `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` | refs | env | ✗ | web3 | web3 | accepted |
-| `NEXT_PUBLIC_TOKEN_SALE_DATE` | refs | DB config | ✗ | ✗ | token sale | needs discussion |
+| `NEXT_PUBLIC_TOKEN_SALE_DATE` | refs | env | ✗ | ✗ | token sale | accepted* |
 | `NEXT_PUBLIC_DEFAULT_TIMEZONE` | code refs | env fallback | ✗ | ✗ | ✓ | accepted |
-| `NEXT_PUBLIC_FEATURE_CARROTS` | code refs | env gate | ✗ | ✗ | feature | accepted |
-| `NEXT_PUBLIC_FEATURE_SUPPORT_US` | code refs | env gate | ✗ | ✗ | feature | accepted |
-| `SENTRY_DSN` | code refs | env | mixed | ✗ | ✗ | proposed |
-| `NEXT_PUBLIC_SENTRY_DSN` | code refs | env | mixed | ✗ | ✗ | proposed |
+| `NEXT_PUBLIC_FEATURE_CARROTS` | code refs | env gate | ✗ | ✗ | feature | accepted* |
+| `NEXT_PUBLIC_FEATURE_SUPPORT_US` | code refs | env gate | ✗ | ✗ | feature | accepted* |
+| `NEXT_PUBLIC_LOG_REQUESTS` | refs | env | ✗ | ✗ | ✗ | platform |
+| `SENTRY_DSN` | code refs | env | mixed | ✗ | ✗ | platform |
+| `NEXT_PUBLIC_SENTRY_DSN` | code refs | env | mixed | ✗ | ✗ | platform |
 | Public provider keys | shared | env | ✗ | feature | feature | accepted |
 
 **Why each stays put:**
 
 - `NEXT_PUBLIC_API_URL` — needed before the app can fetch backend config
 - `NEXT_PUBLIC_PLATFORM_URL` — canonical public deployment URL
-- `NEXT_PUBLIC_PLATFORM` — legacy id / fallback; keep only if shared code still needs it
-- `NEXT_PUBLIC_CDN_URL` — stays in env until media ownership is clearer
-- `NEXT_PUBLIC_LOG_REQUESTS` — debug switch, not village config
-- `NEXT_PUBLIC_NETWORK` — env-owned blockchain network selector
+- `NEXT_PUBLIC_PLATFORM` — **delete.** No shared code reads it. The only tracked read is `apps/village-app/env.js:97`, a fallback for `NEXT_PUBLIC_PLATFORM_URL` — which provisioning always supplies, so the fallback can never fire. Kept here as a tombstone so an old TDF env doesn't reopen the question.
+- `NEXT_PUBLIC_APP_NAME` — **required, no default.** Not a display name: it is a feature discriminator (16+ `APP_NAME === 'tdf'` branches gating token-sale dashboards, revenue widgets, accounting actions) and the locale-bundle key. Provisioning supplies the **village slug**. Two traps worth knowing: `village-app/_app.tsx` spreads `appConfigFromEnv` **last**, so env beats DB `general.appName` (undocumented, and the only reason villages don't inherit `config.ts`'s `appName: 'tdf'` default); and `loadLocaleData`'s fallback branch currently loads the **Closer** bundle for any unknown app, so the slug only works once that resolver is generic. Both filed.
+- `NEXT_PUBLIC_PLATFORM_NAME` — **delete.** Two sources for one display name is how a village shows its own name in the header and `'This village'` in the footer. `general.platformName` is the single source; it is already seeded end-to-end from the API's `PLATFORM_NAME`.
+- `NEXT_PUBLIC_CDN_URL` — stays in env: platform-owned storage, and it is where uploads land regardless of who owns the pointer to them.
+- `NEXT_PUBLIC_NETWORK` — env-owned blockchain network selector. `accepted*`: **revisit when a village enables web3.** Every web3 gate defaults false, so it cannot reach the MVP path.
 - `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` — public WalletConnect key
-- `NEXT_PUBLIC_TOKEN_SALE_DATE` — smells like campaign config; check usage before adding a DB field
+- `NEXT_PUBLIC_TOKEN_SALE_DATE` — stays in env for now. It probably *is* campaign config that belongs in DB, but it is token-sale-gated and reaches no current village. `accepted*`: **revisit with the token sale.**
 - `NEXT_PUBLIC_DEFAULT_TIMEZONE` — fallback only; `general.timeZone` wins once config loads
-- `NEXT_PUBLIC_FEATURE_*` — env is **only** the capability gate: it gates whole routes + nav from `process.env` at build/server time, so it can't become pure DB config. The per-village on/off already lives in DB (`fundraiser.enabled`, feature buckets), not env.
-- Sentry values — deployment observability, not village config
+- `NEXT_PUBLIC_FEATURE_*` — env is the capability gate: it gates whole routes + nav from `process.env` at build/server time. `accepted*`: **revisit after launch** — see the two-switch rule in §4 for why moving them to DB is neither obviously right nor free.
+- Sentry / log switches — see §4a, platform-owned
 - Public provider keys — Firebase, Google Maps, Stripe publishable, WalletConnect, analytics
 
 ---
@@ -120,13 +149,26 @@ Prebuild fetches backend `/config` → writes `packages/closer/generated/appConf
 
 | Concern | Source | Target | Secret | Deploy | Launch | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| `/config` rows | shared + village + refs | snapshot | ✗ | ✓ | ✓ | proposed |
+| `/config` rows | shared + village + refs | snapshot | ✗ | ✓ | ✓ | accepted |
 | `general` snapshot | shared + village + refs | snapshot | ✗ | ✓ | ✓ | accepted |
-| `booking` snapshot | `apps/lios` | snapshot | ✗ | ✗ | maybe | needs discussion |
+| `booking` snapshot | `apps/lios` | snapshot | ✗ | ✓ | ✓ | accepted |
 
-- `/config` rows — pick the required bucket subset after row-level review
+- `/config` rows — **six buckets are mandatory for deploy**: `general`, `events`, `booking`, `subscriptions`, `payment`, `web3`. Everything else is launch-time: seeded as an explicit neutral row when a village turns that feature on. Each of the six earns its place for a specific reason, not by category — see the table below.
 - `general` snapshot — seeds identity, locale, currency, timezone, footer, page metadata
-- `booking` snapshot — split booking policy from homepage content before coding
+- `booking` snapshot — mandatory on **crash-avoidance** grounds: `getSettings('booking')` is dereferenced at 26 API call sites. The old worry ("split booking policy from homepage content first") is resolved: homepage content is CMS page documents, a separate concern entirely, so there is nothing left to split.
+
+**Why each mandatory bucket is mandatory:**
+
+| Bucket | Reason |
+| --- | --- |
+| `general` | The single biggest leak surface — every unset key backfills from a TDF literal (name, canonical URL, legal address, socials, Facebook pixel, FAQ sheet id). |
+| `events` | The only bucket with **no env gate at all**, and its `enabled` default is inverted (`!== false`), so a fresh village gets Events on unconditionally. |
+| `booking` | 26 API dereferences; commerce gate must be explicitly off. |
+| `subscriptions` | Commerce gate off. |
+| `payment` | VAT rate defaults to Portugal's `0.23` — wrong by default for any non-PT village. |
+| `web3` | `bookingToken` defaults to `'TDF'`, which surfaces through the member menu. |
+
+> Two seeding bugs exist **today**, independent of any decision here, and should be fixed with whatever writes these buckets: `booking` is seeded in a legacy nested shape the UI schema no longer expects, and `subscriptions` is seeded as `{plans: []}` while the UI reads `elements`.
 
 **Which API the prebuild fetches from.** The prebuild reads `CONFIG_BUILD_API_URL` if set, falling back to `NEXT_PUBLIC_API_URL` (#942). Provisioned villages set it to the DigitalOcean ingress, because at build time the branded API domain may not resolve yet (closer-procurement#546). The fetch retries with backoff and **fails the build** if the API answers with an error — a village never ships a silently stale snapshot. Two paths still degrade quietly and matter for row decisions: neither URL set at all skips the fetch and keeps whatever snapshot the build started with, and a missing snapshot file is bootstrapped to `{}`, leaving pages on schema defaults.
 
@@ -142,17 +184,17 @@ Editable per village through backend config.
 | --- | --- | --- | --- | --- | --- | --- |
 | Village identity | village + refs | `general` | ✗ | ✗ | ✓ | accepted |
 | Footer social/contact | refs | `general` | ✗ | ✗ | ✓ | accepted |
-| FAQ sheet id | refs | CMS or `general` | ✗ | ✗ | FAQ | needs discussion |
+| FAQ sheet id | refs | **CMS** — remove the field | ✗ | ✗ | FAQ | accepted |
 | Feature enablement | shared | feature buckets | ✗ | ✗ | feature | accepted |
-| Support settings | `apps/moos` | `fundraiser` | ✗ | ✗ | support | proposed |
-| Page metadata | refs | `general` + CMS | ✗ | ✗ | page | proposed |
+| Support settings | `apps/moos` | `fundraiser` | ✗ | ✗ | support | accepted |
+| Page metadata | refs | `general` + CMS | ✗ | ✗ | page | accepted |
 
 - Village identity — public name, app id, canonical URL, contact, timezone
-- Footer social/contact — part of the Village Brand Kit
-- FAQ sheet id — prefer CMS FAQ blocks if they can replace Google Sheets
+- Footer social/contact — village identity, lives in `general`
+- FAQ sheet id — **CMS FAQ blocks; `faqsGoogleSheetId` comes out of the schema entirely.** It is not an inert default: `isFaqEnabled` is `Boolean(config?.FAQS_GOOGLE_SHEET_ID)`, so inheriting TDF's value *force-enables* a TDF FAQ link in a fresh village's menu. Removing the field is required regardless of when TDF itself migrates off Sheets (post-MVP) — new villages simply never get the Sheets path.
 - Feature enablement — booking, volunteering, citizenship, learning hub, affiliate, fundraiser flags
-- Support settings — `apps/moos` uses fundraiser config for support-page availability + credit price
-- Page metadata — identity stays in `general`; page bodies go to CMS
+- Support settings — `apps/moos` uses fundraiser config for support-page availability + credit price. Stays where it is; feature-gated off by default. The hazard was never the row but `fundraiser`'s schema defaults (TDF campaign copy including a live Stripe price id), which the neutral-defaults rule in §4 now covers.
+- Page metadata — identity (name, canonical URL, OG defaults) stays in `general`; per-page titles and descriptions live on the CMS document
 
 ---
 
@@ -164,20 +206,20 @@ Editable per village through backend config.
 | --- | --- | --- | --- | --- | --- | --- |
 | Homepages | refs | CMS | ✗ | ✗ | ✓ | accepted |
 | Nested public pages | `apps/earthbound` | CMS | ✗ | ✗ | page | accepted |
-| Informational pages | closer + foz + moos | CMS or code | ✗ | ✗ | page | needs discussion |
-| Image assets | refs | CMS or Brand Kit | ✗ | ✗ | ✓ | proposed |
-| PDFs | refs | CMS docs | ✗ | ✗ | legal/page | needs discussion |
+| Informational pages | closer + foz + moos | **CMS** | ✗ | ✗ | page | accepted |
+| Image assets | refs | **`general` or CMS** (split by kind) | ✗ | ✗ | ✓ | accepted |
+| PDFs | refs | CMS docs | ✗ | ✗ | legal/page | accepted |
 | App routes | refs | code | ✗ | ✓ | feature | accepted |
-| Footer/layout shell | refs | code + config | ✗ | ✓ | ✓ | proposed |
+| Footer/layout shell | refs | code + config | ✗ | ✓ | ✓ | accepted |
 | Shared behavior | shared | code | ✗ | ✓ | ✓ | accepted |
 
 - Homepages — sections, copy, images, FAQs, CTAs → CMS
 - Nested public pages — `apps/earthbound` needs custom slugs + section rendering
-- Informational pages — split reusable product pages from village editorial pages
-- Image assets — logos → Brand Kit; content images → CMS media
-- PDFs — split public docs from structured legal config
+- Informational pages — CMS page documents on shared routes. Per the content/identity/structure rule: the route is structure (code), the words are content (CMS).
+- Image assets — **no Brand Kit.** Identity images (logo) → `general` (`logoHeader` already exists and is wired end-to-end); hero and content images → CMS media. Brand Kit's real payload was colors and fonts, which cannot reach the frontend at all today (compile-time Tailwind themes), so the bucket would have been a container for values nothing can consume. When theme tokens are solved post-MVP, a Brand Kit can absorb `logoHeader` then.
+- PDFs — CMS file links, not structured config
 - App routes — code owns routes; feature config + nav decide visibility
-- Footer/layout shell — code owns layout; CMS / Brand Kit owns content
+- Footer/layout shell — code owns the shell; `general` + CMS own the content in it
 - Shared behavior — stays in code unless it is a per-village policy
 
 ---
@@ -190,9 +232,23 @@ Editable per village through backend config.
 
 ---
 
-## 10 — 🔥 Still fighting about these
+## 10 — ✅ Settled (was: still fighting about these)
 
-- Which config buckets are **mandatory for deploy** vs just launch-readiness?
-- FAQ: move fully into CMS, or keep Google Sheet support?
-- Which informational pages are reusable product routes vs village-owned CMS pages?
-- Which public documents need structured config instead of CMS file links?
+All four closed on 2026-08-04:
+
+- **Which buckets are mandatory for deploy vs launch?** → the six-bucket set in §6; everything else is launch-time.
+- **FAQ: CMS or Google Sheet?** → CMS blocks; `faqsGoogleSheetId` comes out of the schema (it force-enables a TDF FAQ link today).
+- **Informational pages: product routes or CMS?** → CMS pages on shared routes, per the content/identity/structure rule in §4.
+- **PDFs: structured config or CMS file links?** → CMS file links.
+
+## 11 — ⏭️ Deliberately deferred
+
+Not open questions — decided answers with a named trigger to revisit.
+
+| Item | Revisit when |
+| --- | --- |
+| `NEXT_PUBLIC_FEATURE_*` gates → DB config | After launch |
+| `NEXT_PUBLIC_NETWORK`, `NEXT_PUBLIC_TOKEN_SALE_DATE` | A village enables web3 / the token sale |
+| Theme colors + fonts (config-driven branding) | Post-MVP; needs template work, no seeding path can fix it |
+| TDF's own migration off Google-Sheets FAQ | Post-MVP; does not block new villages |
+| Platform-wide migration of `apps/closer` / TDF off hardcoded config | Post-MVP goal; this pass is the village path only |

--- a/docs/village-app-deployment-config-inventory.md
+++ b/docs/village-app-deployment-config-inventory.md
@@ -8,6 +8,8 @@ Five homes:
 
 > This is a **review**, not a build plan. Nothing gets coded until it reads `accepted`.
 
+> ⚖️ **Open decision, not a settled goal:** whether we should be able to *spin up a new village without touching env vars* is **still a discussion** — not something this deck assumes or commits to. Env vars stay in play until that discussion lands.
+
 ---
 
 ## 1 — Scope

--- a/docs/village-app-deployment-config-inventory.md
+++ b/docs/village-app-deployment-config-inventory.md
@@ -1,12 +1,20 @@
-# Review Village App deployment config
+# 🏘️ Village App Deploy Config — Review Deck
 
-This document inventories the config needed to deploy the generic Village App. Use it to decide what stays in environment variables, what moves to backend database config, what belongs in the Village content management system, and what stays in product code.
+**Every row asks one question: where does this config live?**
 
-This is a review document, not an implementation plan.
+Five homes:
 
-## Decision scope
+`env` · `build snapshot` · `runtime DB` · `CMS` · `code`
 
-Use the smaller Reference Village Apps as the first baseline:
+> This is a **review**, not a build plan. Nothing gets coded until it reads `accepted`.
+
+---
+
+## 1 — Scope
+
+**Small apps first. TDF later.**
+
+Baseline (the small Reference Village Apps):
 
 - `apps/earthbound`
 - `apps/closer`
@@ -15,44 +23,56 @@ Use the smaller Reference Village Apps as the first baseline:
 - `apps/per-auset`
 - `apps/lios`
 
-Exclude `apps/tdf` from this pass. TDF has a larger config footprint and should stress-test the model after this baseline review.
+Skip `apps/tdf` this pass. It is big. Use it to stress-test the model *after* this baseline lands.
 
-## Review legend
+Reference apps are **sources to learn from**, not things we migrate.
 
-| Value | Meaning |
+---
+
+## 2 — The five homes
+
+| Home | Holds |
 | --- | --- |
-| `accepted` | Agreed unless new evidence appears |
-| `proposed` | Likely direction, needs review |
-| `needs discussion` | Do not code yet |
-| `✓` | Required or true |
-| `✗` | Not required or false |
-| `feature` | Required only when that feature launches |
-| `web3` | Required only for web3 deployments |
-| `page` | Required only when that page launches |
+| **Deploy-time env** | Values the app needs *before* it can fetch backend config |
+| **Build snapshot** | Backend `/config` frozen at prebuild → `appConfig.snapshot.json` |
+| **Runtime DB config** | Knobs each village turns itself (product + policy) |
+| **Village CMS** | Pages, homepage sections, media, nav, public copy |
+| **Code** | Routes, shared behavior, flows, product mechanics |
 
-## Agreed rules
+---
 
-- Reference apps are sources for the inventory, not migration targets
-- The first pass combines all smaller Reference Village Apps except TDF
-- Hardcoded village content should move to Village CMS, not database config
-- Public provider keys stay in deploy-time env by default
-- `NEXT_PUBLIC_PLATFORM_URL` is the deployment URL source of truth
-- `general.semanticUrl` should match the deployment URL before launch
-- Feature availability has two layers: env capability gates and per-village database config
+## 3 — How to read the tables
 
-## Target categories
-
-| Target | Use for |
+| Status | Means |
 | --- | --- |
-| Deploy-time env | Values needed before the app can fetch backend config |
-| Build snapshot | Backend `/config` fetched during prebuild |
-| Runtime DB config | Editable per-village product and policy settings |
-| Village CMS | Pages, homepage sections, media, navigation, and public copy |
-| Code | Routes, shared behavior, flows, and product mechanics |
+| `accepted` | Agreed. Move on unless new evidence. |
+| `proposed` | Probably right. Needs a look. |
+| `needs discussion` | **Do not code yet.** |
 
-## Deploy-time env
+| Flag | Means |
+| --- | --- |
+| `✓` / `✗` | Required / not required |
+| `feature` | Only when that feature launches |
+| `web3` | Only for web3 deployments |
+| `page` | Only when that page launches |
 
-These values should stay in environment variables unless review finds a stronger reason to move them.
+---
+
+## 4 — House rules
+
+- Hardcoded village content → **CMS**, not DB config
+- Public provider keys → **stay in env** by default
+- `NEXT_PUBLIC_PLATFORM_URL` = the one true deployment URL
+- `general.semanticUrl` must match that URL before launch
+- Feature availability has **two switches**: env capability gate + per-village DB config
+
+---
+
+## 5 — 🌐 Deploy-time env
+
+**The stuff the app needs before it can even phone home.**
+
+Keep these in env vars unless review finds a strong reason to move them.
 
 | Env var | Source | Target | Secret | Deploy | Launch | Status |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -71,24 +91,28 @@ These values should stay in environment variables unless review finds a stronger
 | `NEXT_PUBLIC_SENTRY_DSN` | code refs | env | mixed | ✗ | ✗ | proposed |
 | Public provider keys | shared | env | ✗ | feature | feature | accepted |
 
-Notes:
+**Why each stays put:**
 
-- `NEXT_PUBLIC_API_URL`: required before the app can fetch backend config
-- `NEXT_PUBLIC_PLATFORM_URL`: canonical public deployment URL
-- `NEXT_PUBLIC_PLATFORM`: legacy identifier or fallback; keep only if shared code still needs it
-- `NEXT_PUBLIC_CDN_URL`: keep in env until media ownership is clearer
-- `NEXT_PUBLIC_LOG_REQUESTS`: debug logging switch, not village config
-- `NEXT_PUBLIC_NETWORK`: environment-owned blockchain network selector
-- `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID`: public WalletConnect project key
-- `NEXT_PUBLIC_TOKEN_SALE_DATE`: likely campaign config; inspect usage before adding a DB field
-- `NEXT_PUBLIC_DEFAULT_TIMEZONE`: fallback only; `general.timeZone` should win after config loads
-- `NEXT_PUBLIC_FEATURE_CARROTS` and `NEXT_PUBLIC_FEATURE_SUPPORT_US`: env gates availability; DB config enables each village
-- Sentry values: deployment observability, not village config
-- Public provider keys: Firebase, Google Maps, Stripe publishable keys, WalletConnect, analytics
+- `NEXT_PUBLIC_API_URL` — needed before the app can fetch backend config
+- `NEXT_PUBLIC_PLATFORM_URL` — canonical public deployment URL
+- `NEXT_PUBLIC_PLATFORM` — legacy id / fallback; keep only if shared code still needs it
+- `NEXT_PUBLIC_CDN_URL` — stays in env until media ownership is clearer
+- `NEXT_PUBLIC_LOG_REQUESTS` — debug switch, not village config
+- `NEXT_PUBLIC_NETWORK` — env-owned blockchain network selector
+- `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` — public WalletConnect key
+- `NEXT_PUBLIC_TOKEN_SALE_DATE` — smells like campaign config; check usage before adding a DB field
+- `NEXT_PUBLIC_DEFAULT_TIMEZONE` — fallback only; `general.timeZone` wins once config loads
+- `NEXT_PUBLIC_FEATURE_*` — env gates the capability; DB config enables each village
+- Sentry values — deployment observability, not village config
+- Public provider keys — Firebase, Google Maps, Stripe publishable, WalletConnect, analytics
 
-## Build-time DB snapshot
+---
 
-The prebuild flow fetches backend `/config` and writes `packages/closer/generated/appConfig.snapshot.json`.
+## 6 — 📦 Build-time DB snapshot
+
+**Config frozen at build time.**
+
+Prebuild fetches backend `/config` → writes `packages/closer/generated/appConfig.snapshot.json`.
 
 | Concern | Source | Target | Secret | Deploy | Launch | Status |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -96,15 +120,17 @@ The prebuild flow fetches backend `/config` and writes `packages/closer/generate
 | `general` snapshot | shared + village + refs | snapshot | ✗ | ✓ | ✓ | accepted |
 | `booking` snapshot | `apps/lios` | snapshot | ✗ | ✗ | maybe | needs discussion |
 
-Notes:
+- `/config` rows — pick the required bucket subset after row-level review
+- `general` snapshot — seeds identity, locale, currency, timezone, footer, page metadata
+- `booking` snapshot — split booking policy from homepage content before coding
 
-- `/config` rows: decide the required bucket subset after row-level review
-- `general` snapshot: seeds identity, locale, currency, timezone, footer, and page metadata
-- `booking` snapshot: separate booking policy from homepage content before coding
+---
 
-## Runtime DB config
+## 7 — 🎛️ Runtime DB config
 
-These values should be editable per village through backend config.
+**Knobs each village turns itself.**
+
+Editable per village through backend config.
 
 | Concern | Source | Target | Secret | Deploy | Launch | Status |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -115,18 +141,18 @@ These values should be editable per village through backend config.
 | Support settings | `apps/moos` | `fundraiser` | ✗ | ✗ | support | proposed |
 | Page metadata | refs | `general` + CMS | ✗ | ✗ | page | proposed |
 
-Notes:
+- Village identity — public name, app id, canonical URL, contact, timezone
+- Footer social/contact — part of the Village Brand Kit
+- FAQ sheet id — prefer CMS FAQ blocks if they can replace Google Sheets
+- Feature enablement — booking, volunteering, citizenship, learning hub, affiliate, fundraiser flags
+- Support settings — `apps/moos` uses fundraiser config for support-page availability + credit price
+- Page metadata — identity stays in `general`; page bodies go to CMS
 
-- Village identity: public name, app id, canonical URL, contact details, and timezone
-- Footer social/contact: part of the Village Brand Kit
-- FAQ sheet id: prefer CMS FAQ blocks if they can replace Google Sheets
-- Feature enablement: includes booking, volunteering, citizenship, learning hub, affiliate, and fundraiser flags
-- Support settings: `apps/moos` uses fundraiser config for support page availability and credit price display
-- Page metadata: keep identity in `general`; move page bodies to CMS
+---
 
-## Code or CMS, not DB config
+## 8 — 📝 Code or CMS — NOT DB config
 
-These concerns should not become database config by default.
+**Content and behavior. Not database rows.**
 
 | Concern | Source | Target | Secret | Deploy | Launch | Status |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -139,26 +165,28 @@ These concerns should not become database config by default.
 | Footer/layout shell | refs | code + config | ✗ | ✓ | ✓ | proposed |
 | Shared behavior | shared | code | ✗ | ✓ | ✓ | accepted |
 
-Notes:
+- Homepages — sections, copy, images, FAQs, CTAs → CMS
+- Nested public pages — `apps/earthbound` needs custom slugs + section rendering
+- Informational pages — split reusable product pages from village editorial pages
+- Image assets — logos → Brand Kit; content images → CMS media
+- PDFs — split public docs from structured legal config
+- App routes — code owns routes; feature config + nav decide visibility
+- Footer/layout shell — code owns layout; CMS / Brand Kit owns content
+- Shared behavior — stays in code unless it is a per-village policy
 
-- Homepages: move sections, copy, images, FAQs, and calls to action to CMS
-- Nested public pages: `apps/earthbound` needs custom slugs and section rendering
-- Informational pages: split reusable product pages from village-owned editorial pages
-- Image assets: logos belong in Brand Kit; content images belong in CMS media
-- PDFs: separate public documents from structured legal config
-- App routes: code owns routes; feature config and navigation decide visibility
-- Footer/layout shell: code owns layout; CMS or Brand Kit owns content
-- Shared behavior: keep in code unless it is a per-village policy
+---
 
-## Do not migrate
+## 9 — 🚫 Never migrate these
 
-- Secrets must not move to public env or editable DB config
-- Deployment infrastructure values should not become Village Brand Kit fields
-- Bespoke page content should move to Village CMS, not runtime DB config
+- **Secrets** → never public env, never editable DB config
+- **Deployment infra values** → never Brand Kit fields
+- **Bespoke page content** → CMS, never runtime DB config
 
-## Open questions
+---
 
-- Which config buckets are mandatory for deployment, and which are only launch readiness?
-- Should FAQ content move fully into CMS, or keep Google Sheet support?
-- Which informational pages are reusable product routes versus village-owned CMS pages?
+## 10 — 🔥 Still fighting about these
+
+- Which config buckets are **mandatory for deploy** vs just launch-readiness?
+- FAQ: move fully into CMS, or keep Google Sheet support?
+- Which informational pages are reusable product routes vs village-owned CMS pages?
 - Which public documents need structured config instead of CMS file links?

--- a/docs/village-app-deployment-config-inventory.md
+++ b/docs/village-app-deployment-config-inventory.md
@@ -1,0 +1,164 @@
+# Review Village App deployment config
+
+This document inventories the config needed to deploy the generic Village App. Use it to decide what stays in environment variables, what moves to backend database config, what belongs in the Village content management system, and what stays in product code.
+
+This is a review document, not an implementation plan.
+
+## Decision scope
+
+Use the smaller Reference Village Apps as the first baseline:
+
+- `apps/earthbound`
+- `apps/closer`
+- `apps/foz`
+- `apps/moos`
+- `apps/per-auset`
+- `apps/lios`
+
+Exclude `apps/tdf` from this pass. TDF has a larger config footprint and should stress-test the model after this baseline review.
+
+## Review legend
+
+| Value | Meaning |
+| --- | --- |
+| `accepted` | Agreed unless new evidence appears |
+| `proposed` | Likely direction, needs review |
+| `needs discussion` | Do not code yet |
+| `✓` | Required or true |
+| `✗` | Not required or false |
+| `feature` | Required only when that feature launches |
+| `web3` | Required only for web3 deployments |
+| `page` | Required only when that page launches |
+
+## Agreed rules
+
+- Reference apps are sources for the inventory, not migration targets
+- The first pass combines all smaller Reference Village Apps except TDF
+- Hardcoded village content should move to Village CMS, not database config
+- Public provider keys stay in deploy-time env by default
+- `NEXT_PUBLIC_PLATFORM_URL` is the deployment URL source of truth
+- `general.semanticUrl` should match the deployment URL before launch
+- Feature availability has two layers: env capability gates and per-village database config
+
+## Target categories
+
+| Target | Use for |
+| --- | --- |
+| Deploy-time env | Values needed before the app can fetch backend config |
+| Build snapshot | Backend `/config` fetched during prebuild |
+| Runtime DB config | Editable per-village product and policy settings |
+| Village CMS | Pages, homepage sections, media, navigation, and public copy |
+| Code | Routes, shared behavior, flows, and product mechanics |
+
+## Deploy-time env
+
+These values should stay in environment variables unless review finds a stronger reason to move them.
+
+| Env var | Source | Target | Secret | Deploy | Launch | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `NEXT_PUBLIC_API_URL` | village + refs | env | ✗ | ✓ | ✓ | accepted |
+| `NEXT_PUBLIC_PLATFORM_URL` | village + refs | env | ✗ | ✓ | ✓ | accepted |
+| `NEXT_PUBLIC_PLATFORM` | refs | env | ✗ | ✗ | ✗ | proposed |
+| `NEXT_PUBLIC_CDN_URL` | village + refs | env | ✗ | ✗ | maybe | proposed |
+| `NEXT_PUBLIC_LOG_REQUESTS` | refs | env | ✗ | ✗ | ✗ | proposed |
+| `NEXT_PUBLIC_NETWORK` | refs | env | ✗ | web3 | web3 | proposed |
+| `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` | refs | env | ✗ | web3 | web3 | accepted |
+| `NEXT_PUBLIC_TOKEN_SALE_DATE` | refs | DB config | ✗ | ✗ | token sale | needs discussion |
+| `NEXT_PUBLIC_DEFAULT_TIMEZONE` | code refs | env fallback | ✗ | ✗ | ✓ | accepted |
+| `NEXT_PUBLIC_FEATURE_CARROTS` | code refs | env gate | ✗ | ✗ | feature | accepted |
+| `NEXT_PUBLIC_FEATURE_SUPPORT_US` | code refs | env gate | ✗ | ✗ | feature | accepted |
+| `SENTRY_DSN` | code refs | env | mixed | ✗ | ✗ | proposed |
+| `NEXT_PUBLIC_SENTRY_DSN` | code refs | env | mixed | ✗ | ✗ | proposed |
+| Public provider keys | shared | env | ✗ | feature | feature | accepted |
+
+Notes:
+
+- `NEXT_PUBLIC_API_URL`: required before the app can fetch backend config
+- `NEXT_PUBLIC_PLATFORM_URL`: canonical public deployment URL
+- `NEXT_PUBLIC_PLATFORM`: legacy identifier or fallback; keep only if shared code still needs it
+- `NEXT_PUBLIC_CDN_URL`: keep in env until media ownership is clearer
+- `NEXT_PUBLIC_LOG_REQUESTS`: debug logging switch, not village config
+- `NEXT_PUBLIC_NETWORK`: environment-owned blockchain network selector
+- `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID`: public WalletConnect project key
+- `NEXT_PUBLIC_TOKEN_SALE_DATE`: likely campaign config; inspect usage before adding a DB field
+- `NEXT_PUBLIC_DEFAULT_TIMEZONE`: fallback only; `general.timeZone` should win after config loads
+- `NEXT_PUBLIC_FEATURE_CARROTS` and `NEXT_PUBLIC_FEATURE_SUPPORT_US`: env gates availability; DB config enables each village
+- Sentry values: deployment observability, not village config
+- Public provider keys: Firebase, Google Maps, Stripe publishable keys, WalletConnect, analytics
+
+## Build-time DB snapshot
+
+The prebuild flow fetches backend `/config` and writes `packages/closer/generated/appConfig.snapshot.json`.
+
+| Concern | Source | Target | Secret | Deploy | Launch | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| `/config` rows | shared + village + refs | snapshot | ✗ | ✓ | ✓ | proposed |
+| `general` snapshot | shared + village + refs | snapshot | ✗ | ✓ | ✓ | accepted |
+| `booking` snapshot | `apps/lios` | snapshot | ✗ | ✗ | maybe | needs discussion |
+
+Notes:
+
+- `/config` rows: decide the required bucket subset after row-level review
+- `general` snapshot: seeds identity, locale, currency, timezone, footer, and page metadata
+- `booking` snapshot: separate booking policy from homepage content before coding
+
+## Runtime DB config
+
+These values should be editable per village through backend config.
+
+| Concern | Source | Target | Secret | Deploy | Launch | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Village identity | village + refs | `general` | ✗ | ✗ | ✓ | accepted |
+| Footer social/contact | refs | `general` | ✗ | ✗ | ✓ | accepted |
+| FAQ sheet id | refs | CMS or `general` | ✗ | ✗ | FAQ | needs discussion |
+| Feature enablement | shared | feature buckets | ✗ | ✗ | feature | accepted |
+| Support settings | `apps/moos` | `fundraiser` | ✗ | ✗ | support | proposed |
+| Page metadata | refs | `general` + CMS | ✗ | ✗ | page | proposed |
+
+Notes:
+
+- Village identity: public name, app id, canonical URL, contact details, and timezone
+- Footer social/contact: part of the Village Brand Kit
+- FAQ sheet id: prefer CMS FAQ blocks if they can replace Google Sheets
+- Feature enablement: includes booking, volunteering, citizenship, learning hub, affiliate, and fundraiser flags
+- Support settings: `apps/moos` uses fundraiser config for support page availability and credit price display
+- Page metadata: keep identity in `general`; move page bodies to CMS
+
+## Code or CMS, not DB config
+
+These concerns should not become database config by default.
+
+| Concern | Source | Target | Secret | Deploy | Launch | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| Homepages | refs | CMS | ✗ | ✗ | ✓ | accepted |
+| Nested public pages | `apps/earthbound` | CMS | ✗ | ✗ | page | accepted |
+| Informational pages | closer + foz + moos | CMS or code | ✗ | ✗ | page | needs discussion |
+| Image assets | refs | CMS or Brand Kit | ✗ | ✗ | ✓ | proposed |
+| PDFs | refs | CMS docs | ✗ | ✗ | legal/page | needs discussion |
+| App routes | refs | code | ✗ | ✓ | feature | accepted |
+| Footer/layout shell | refs | code + config | ✗ | ✓ | ✓ | proposed |
+| Shared behavior | shared | code | ✗ | ✓ | ✓ | accepted |
+
+Notes:
+
+- Homepages: move sections, copy, images, FAQs, and calls to action to CMS
+- Nested public pages: `apps/earthbound` needs custom slugs and section rendering
+- Informational pages: split reusable product pages from village-owned editorial pages
+- Image assets: logos belong in Brand Kit; content images belong in CMS media
+- PDFs: separate public documents from structured legal config
+- App routes: code owns routes; feature config and navigation decide visibility
+- Footer/layout shell: code owns layout; CMS or Brand Kit owns content
+- Shared behavior: keep in code unless it is a per-village policy
+
+## Do not migrate
+
+- Secrets must not move to public env or editable DB config
+- Deployment infrastructure values should not become Village Brand Kit fields
+- Bespoke page content should move to Village CMS, not runtime DB config
+
+## Open questions
+
+- Which config buckets are mandatory for deployment, and which are only launch readiness?
+- Should FAQ content move fully into CMS, or keep Google Sheet support?
+- Which informational pages are reusable product routes versus village-owned CMS pages?
+- Which public documents need structured config instead of CMS file links?

--- a/docs/village-app-deployment-config-inventory.md
+++ b/docs/village-app-deployment-config-inventory.md
@@ -64,7 +64,9 @@ Reference apps are **sources to learn from**, not things we migrate.
 - Public provider keys → **stay in env** by default
 - `NEXT_PUBLIC_PLATFORM_URL` = the one true deployment URL
 - `general.semanticUrl` must match that URL before launch
-- Feature availability has **two switches**: env capability gate + per-village DB config
+- Feature availability has **two switches — both must be on:**
+  - **env gate** (`NEXT_PUBLIC_FEATURE_*`) — compiled per deployment. If not `true`, the code path is dead: route 404s, nav item hidden. This is the *capability* switch, read from `process.env` at build/server time.
+  - **DB config** — per-village `enabled` flag (e.g. `fundraiser.enabled`). This is the *per-village* switch.
 
 ---
 
@@ -102,7 +104,7 @@ Keep these in env vars unless review finds a strong reason to move them.
 - `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` — public WalletConnect key
 - `NEXT_PUBLIC_TOKEN_SALE_DATE` — smells like campaign config; check usage before adding a DB field
 - `NEXT_PUBLIC_DEFAULT_TIMEZONE` — fallback only; `general.timeZone` wins once config loads
-- `NEXT_PUBLIC_FEATURE_*` — env gates the capability; DB config enables each village
+- `NEXT_PUBLIC_FEATURE_*` — env is **only** the capability gate: it gates whole routes + nav from `process.env` at build/server time, so it can't become pure DB config. The per-village on/off already lives in DB (`fundraiser.enabled`, feature buckets), not env.
 - Sentry values — deployment observability, not village config
 - Public provider keys — Firebase, Google Maps, Stripe publishable, WalletConnect, analytics
 


### PR DESCRIPTION
## Summary
- add stakeholder-facing inventory for Village App deployment config decisions
- document how to classify deploy-time env, build-time DB snapshots, runtime DB config, and CMS/code-only concerns
- use the smaller Reference Village Apps as the first baseline and defer TDF as a later stress test

## Review focus
- Are the target categories right for the baseline smaller Reference Village Apps?
- Which proposed or needs-discussion rows should become implementation tickets later?
- Are any launch-readiness requirements missing from the inventory?

## Tests
- Not run; documentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a deployment-configuration review guide covering configuration ownership, status conventions, and approved storage locations.
  * Documented environment variables, build-time snapshots, runtime settings, CMS content, secrets, infrastructure values, and deferred migrations.
  * Clarified standard provisioning, Stripe Connect requirements, snapshot handling, CMS ownership, and removal of the FAQ Sheets field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->