### PR TITLE
fix(bookings): hide draft bookings from admin list by default

### DIFF
--- a/packages/closer/components/BookingsFilter/index.test.tsx
+++ b/packages/closer/components/BookingsFilter/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithNextIntl } from '../../test/utils';
 
 import BookingsFilter from './index';
@@ -38,5 +38,45 @@ describe('BookingsFilter', () => {
     expect(newestFirstButton).toBeInTheDocument();
     expect(departureButton).toBeEnabled();
     expect(datesButton).toBeInTheDocument();
+  });
+
+  it('should apply the default where clause when no status is selected', () => {
+    const setFilter = jest.fn();
+    const defaultWhere = { status: { $nin: ['open', 'draft'] } };
+
+    renderWithNextIntl(
+      <BookingsFilter
+        setPage={jest.fn()}
+        page={1}
+        defaultWhere={defaultWhere}
+        setFilter={setFilter}
+      />,
+    );
+
+    expect(setFilter).toHaveBeenCalledWith(
+      expect.objectContaining({ where: defaultWhere }),
+    );
+  });
+
+  it('should override the default where clause when drafts are selected', () => {
+    const setFilter = jest.fn();
+    const defaultWhere = { status: { $nin: ['open', 'draft'] } };
+
+    renderWithNextIntl(
+      <BookingsFilter
+        setPage={jest.fn()}
+        page={1}
+        defaultWhere={defaultWhere}
+        setFilter={setFilter}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.change(screen.getAllByRole('combobox')[0], {
+      target: { value: 'draft' },
+    });
+
+    const lastFilter = setFilter.mock.calls[setFilter.mock.calls.length - 1][0];
+    expect(lastFilter.where).toEqual({ status: ['draft'] });
   });
 });

--- a/packages/closer/components/BookingsFilter/index.tsx
+++ b/packages/closer/components/BookingsFilter/index.tsx
@@ -102,11 +102,6 @@ const BookingsFilter = ({ setFilter, page, setPage, defaultWhere }: Props) => {
     const dateFromObj = new Date(filterValues.dateFrom);
     dateFromObj.setDate(dateFromObj.getDate() - 1);
 
-    const isDefaultFilter =
-      !filterValues.dateTo &&
-      !filterValues.dateFrom &&
-      filterValues.status === 'any';
-
     const getFilter = {
       where: {
         ...(filterValues.type === 'event' && { eventId: { $exists: true } }),
@@ -123,7 +118,7 @@ const BookingsFilter = ({ setFilter, page, setPage, defaultWhere }: Props) => {
         }),
         ...(filterValues.status !== 'any'
           ? { status: [bookingStatus] }
-          : { status: { $ne: 'open' } }),
+          : defaultWhere),
         ...(filterValues.bookingId !== '' && { _id: filterValues.bookingId }),
         ...(filterValues.selectedEvent.label !== 'any' && {
           eventId: filterValues.selectedEvent.value,
@@ -135,7 +130,6 @@ const BookingsFilter = ({ setFilter, page, setPage, defaultWhere }: Props) => {
               $gte: dateFromObj,
             },
           }),
-        ...(isDefaultFilter && defaultWhere),
       },
       limit: BOOKINGS_PER_PAGE,
       sort_by: filterValues.sortBy,

--- a/packages/closer/constants/shared.constants.ts
+++ b/packages/closer/constants/shared.constants.ts
@@ -321,6 +321,7 @@ export const INTERACTION_IS_HUMAN_EVENT = 'closer-interaction-is-human';
 export const BOOKING_STATUS_OPTIONS = [
   { label: 'Any', value: 'any' },
   { label: 'Open', value: 'open' },
+  { label: 'Draft', value: 'draft' },
   { label: 'Pending', value: 'pending' },
   { label: 'Confirmed', value: 'confirmed' },
   { label: 'Paid', value: 'paid' },

--- a/packages/closer/pages/bookings/all.tsx
+++ b/packages/closer/pages/bookings/all.tsx
@@ -29,7 +29,7 @@ const AllBookingsRequestsPage = ({ bookingConfig }: Props) => {
   const { user } = useAuth();
 
   const defaultWhere = {
-    status: { $ne: 'open' },
+    status: { $nin: ['open', 'draft'] },
   };
 
   const [filter, setFilter] = useState({


### PR DESCRIPTION
Ops ticket #13. Draft bookings (`status: 'draft'`, the entry state of the stays flow) were leaking into the admin bookings list and creating daily noise for the ground team.

## Behaviour

- Drafts are hidden **by default** on `/bookings/all`.
- Drafts remain reachable on demand via a new **Draft** option in the status filter.
- No data is deleted or migrated.

## Why `BookingsFilter` was touched, and not just the default filter

This is the important part of the review, and it is not cleanup.

`BookingsFilter` built its query from two sources: an inline `: { status: { $ne: 'open' } }` fallback in the status ternary, and a trailing `...(isDefaultFilter && defaultWhere)` guarded on `!dateTo && !dateFrom && status === 'any'`.

Because `defaultWhere` was previously **byte-identical** to that hardcoded fallback, the guard's dead-drop was invisible. The moment the default diverges to `$nin: ['open', 'draft']`, it becomes a live bug:

> Admin opens `/bookings/all` — drafts correctly hidden. Admin picks any date range → `isDefaultFilter` goes false → `where.status` reverts to `{ $ne: 'open' }` → **every draft reappears.**

The ticket would have looked fixed on load and silently regressed on the most common admin interaction. So the ternary's "no status selected" branch now spreads `defaultWhere` directly, making the page-level default the single source of truth, and the redundant trailing spread is gone.

`BookingsFilter` has exactly one consumer (`pages/bookings/all.tsx`), so nothing else is affected. (`pages/bookings/requests.tsx` has it commented out and hardcodes `status: 'pending'`.)

## Verification

- `jest components/BookingsFilter` — 3/3 pass (1 pre-existing + 2 added covering the default and the opt-in)
- `jest` in `packages/closer` — 10 suites, 129 pass / 2 skipped
- `jest` in `apps/tdf` — 18 suites, 45 pass
- `tsc --noEmit` — 249 vs a 246 baseline on `develop`. The +3 are in `index.test.tsx` and are the same pre-existing chai/jest global-collision class as the 7 errors already in that file, not real type errors.
- Opt-in traced end-to-end: selecting Draft emits `where: { status: ['draft'] }`; `sanitizeFilter` passes arrays through, and Mongoose casts a bare array to `$in`. It genuinely returns rows rather than an always-empty list.
- Status string confirmed against `utils/stays/status.js:13` and `routes/stays/cart.js:133`.

## Noted, not fixed here

`BOOKING_STATUS_OPTIONS` omits `pending-payment`, `rejected` and `cancelled`, and offers `Checked-in`/`Checked-out` — which are **not statuses**; presence is stored as `checkedIn`/`checkedOut` Date fields. Those two options return zero rows today. Pre-existing and out of scope, but it means the status filter is less sound than it looks. Relates to ticket #14.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Draft** status option to booking filters.
  * Default booking views now exclude both open and draft bookings.

* **Bug Fixes**
  * Improved booking filter behavior so default conditions apply correctly.
  * Selecting a specific status, such as Draft, now properly overrides default filters.

* **Tests**
  * Added coverage for default filter conditions and status selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->