### PR TITLE
fix(bookings): disable station pickup everywhere it still renders (#1, #2)

### DIFF
--- a/packages/closer/components/BookingListPreview/BookingListPreview.tsx
+++ b/packages/closer/components/BookingListPreview/BookingListPreview.tsx
@@ -120,7 +120,9 @@ const BookingListPreview = ({
     : { fiatOwed: 0, tokensOwed: 0, creditsOwed: 0 };
 
   const flagPickup =
-    doesNeedPickup && start > new Date(Date.now() - 12 * 60 * 60 * 1000);
+    bookingConfig?.pickUpEnabled &&
+    doesNeedPickup &&
+    start > new Date(Date.now() - 12 * 60 * 60 * 1000);
   const startFormatted = dayjs(start).format('DD/MM/YYYY');
 
   const endFormatted = dayjs(end).format('DD/MM/YYYY');

--- a/packages/closer/components/Bookings.tsx
+++ b/packages/closer/components/Bookings.tsx
@@ -128,7 +128,9 @@ const Bookings = ({
       { label: 'Guests', key: 'guests' },
       { label: 'Volunteer', key: 'volunteer' },
       { label: 'Arrival', key: 'arrival' },
-      { label: 'Pickup', key: 'pickup' },
+      ...(bookingConfig?.pickUpEnabled
+        ? [{ label: 'Pickup', key: 'pickup' }]
+        : []),
       { label: 'Total', key: 'total' },
     ];
     const data = bookings
@@ -151,7 +153,9 @@ const Bookings = ({
           guests: booking.get('adults'),
           volunteer: booking.get('volunteerId'),
           arrival: booking.get('start'),
-          pickup: booking.get('doesNeedPickup'),
+          ...(bookingConfig?.pickUpEnabled
+            ? { pickup: booking.get('doesNeedPickup') }
+            : {}),
           total:
             booking.getIn(['total', 'val']) ??
             booking.getIn(['priceLock', 'total', 'val']) ??
@@ -175,7 +179,7 @@ const Bookings = ({
     link.download = `bookings-${dayjs().format('YYYY-MM-DD.HH:mm')}.csv`;
     link.click();
     URL.revokeObjectURL(link.href);
-  }, [bookings, platform]);
+  }, [bookings, platform, bookingConfig]);
 
   if (error) {
     return <div className="validation-error">{JSON.stringify(error)}</div>;

--- a/packages/closer/components/CurrentBooking.js
+++ b/packages/closer/components/CurrentBooking.js
@@ -29,7 +29,7 @@ dayjs.extend(isSameOrBefore);
 
 const MAX_USERS_TO_FETCH = 2000;
 
-const CurrentBooking = ({ leftAfter, arriveBefore }) => {
+const CurrentBooking = ({ leftAfter, arriveBefore, bookingConfig }) => {
   const t = useTranslations();
 
   const { platform } = usePlatform();
@@ -286,7 +286,9 @@ const CurrentBooking = ({ leftAfter, arriveBefore }) => {
                 <TableHead>{t('current_booking_table_duration')}</TableHead>
                 <TableHead>{t('current_booking_table_status')}</TableHead>
                 <TableHead>{t('current_booking_table_total')}</TableHead>
-                <TableHead>{t('current_booking_table_pickup')}</TableHead>
+                {bookingConfig?.pickUpEnabled && (
+                  <TableHead>{t('current_booking_table_pickup')}</TableHead>
+                )}
                 <TableHead>
                   {t('current_booking_table_separate_beds')}
                 </TableHead>
@@ -425,15 +427,17 @@ const CurrentBooking = ({ leftAfter, arriveBefore }) => {
                         )}
                       </div>
                     </TableCell>
-                    <TableCell className="whitespace-nowrap">
-                      <div className="text-center">
-                        {b.doesNeedPickup ? (
-                          <span className="text-red-600">🚗</span>
-                        ) : (
-                          <span className="text-gray-400">-</span>
-                        )}
-                      </div>
-                    </TableCell>
+                    {bookingConfig?.pickUpEnabled && (
+                      <TableCell className="whitespace-nowrap">
+                        <div className="text-center">
+                          {b.doesNeedPickup ? (
+                            <span className="text-red-600">🚗</span>
+                          ) : (
+                            <span className="text-gray-400">-</span>
+                          )}
+                        </div>
+                      </TableCell>
+                    )}
                     <TableCell className="whitespace-nowrap">
                       <div className="text-center">
                         {b.doesNeedSeparateBeds ? (

--- a/packages/closer/components/pickupGating.test.ts
+++ b/packages/closer/components/pickupGating.test.ts
@@ -1,0 +1,81 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Station pickup is disabled platform-wide via the `pickUpEnabled` key on the
+ * `booking` config slug. Every surface that *renders* pickup must read that
+ * flag, or the feature silently reappears for users.
+ *
+ * This is a structural test rather than a render test on purpose. The gap this
+ * guards against was not a logic error — it was `components/CurrentBooking.js`,
+ * an untyped legacy file that no `*.tsx`-scoped search surfaced, rendering a
+ * pickup column in production while the flag was off. A per-component render
+ * test would only have covered the components we already knew about.
+ */
+
+const ROOT = path.join(__dirname, '..');
+const SCAN_DIRS = ['components', 'pages'];
+const CODE_EXT = /\.(js|jsx|ts|tsx)$/;
+
+/**
+ * Files that reference `doesNeedPickup` without reading `pickUpEnabled`, for
+ * reasons that are correct. Keep this list short and justified — adding to it
+ * is how the bug this test exists to catch would come back.
+ */
+const ALLOWED = new Map([
+  [
+    'pages/bookings/create/accomodation.tsx',
+    'Data-only: passes doesNeedPickup through the booking payload, renders no pickup UI.',
+  ],
+  [
+    'components/SummaryDates.tsx',
+    'Gated by contract: renders only when doesNeedPickup !== undefined, and every caller passes undefined when the flag is off.',
+  ],
+]);
+
+const walk = (dir: string): string[] =>
+  fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === 'node_modules' || entry.name === 'generated'
+        ? []
+        : walk(full);
+    }
+    return CODE_EXT.test(entry.name) && !/\.test\.[jt]sx?$/.test(entry.name)
+      ? [full]
+      : [];
+  });
+
+describe('station pickup config gating', () => {
+  const offenders: string[] = [];
+  const allowedSeen = new Set<string>();
+
+  for (const dir of SCAN_DIRS) {
+    for (const file of walk(path.join(ROOT, dir))) {
+      const source = fs.readFileSync(file, 'utf8');
+      if (!source.includes('doesNeedPickup')) continue;
+
+      const rel = path.relative(ROOT, file).split(path.sep).join('/');
+      if (ALLOWED.has(rel)) {
+        allowedSeen.add(rel);
+        continue;
+      }
+      if (!source.includes('pickUpEnabled')) offenders.push(rel);
+    }
+  }
+
+  it('every component or page rendering pickup also reads pickUpEnabled', () => {
+    expect(offenders).toEqual([]);
+  });
+
+  it('has no stale entries in the allowlist', () => {
+    // If a file stops referencing pickup, its exemption should be deleted so the
+    // list keeps meaning something.
+    expect([...ALLOWED.keys()].filter((f) => !allowedSeen.has(f))).toEqual([]);
+  });
+
+  it('scans files regardless of extension, including legacy .js', () => {
+    const scanned = SCAN_DIRS.flatMap((d) => walk(path.join(ROOT, d)));
+    expect(scanned.some((f) => f.endsWith('.js'))).toBe(true);
+  });
+});

--- a/packages/closer/pages/bookings/[slug]/index.tsx
+++ b/packages/closer/pages/bookings/[slug]/index.tsx
@@ -774,7 +774,9 @@ const BookingPage = ({
               eventName={event?.name}
               volunteerName={volunteer?.name}
               ticketOption={ticketOption?.name}
-              doesNeedPickup={doesNeedPickup}
+              doesNeedPickup={
+                bookingConfig?.pickUpEnabled ? doesNeedPickup : undefined
+              }
               doesNeedSeparateBeds={doesNeedSeparateBeds}
               isEditMode={
                 (canManageBooking || canGuestEditBookingDetails) && isEditMode

--- a/packages/closer/pages/bookings/all.tsx
+++ b/packages/closer/pages/bookings/all.tsx
@@ -59,7 +59,12 @@ const AllBookingsRequestsPage = ({ bookingConfig }: Props) => {
           setPage={setPage}
           defaultWhere={defaultWhere}
         />
-        <Bookings filter={filter} setPage={setPage} page={page} />
+        <Bookings
+          filter={filter}
+          setPage={setPage}
+          page={page}
+          bookingConfig={bookingConfig}
+        />
       </AdminLayout>
     </>
   );

--- a/packages/closer/pages/bookings/current.tsx
+++ b/packages/closer/pages/bookings/current.tsx
@@ -47,7 +47,11 @@ const CurrentBookings = ({ bookingConfig }: Props) => {
         <div className="max-w-screen-xl flex flex-col gap-10">
           <Heading level={1}>{t('current_bookings_title')}</Heading>
 
-          <CurrentBooking leftAfter={threeDaysAgo} arriveBefore={inSevenDays} />
+          <CurrentBooking
+            leftAfter={threeDaysAgo}
+            arriveBefore={inSevenDays}
+            bookingConfig={bookingConfig}
+          />
         </div>
       </AdminLayout>
     </>

--- a/packages/closer/pages/bookings/requests.tsx
+++ b/packages/closer/pages/bookings/requests.tsx
@@ -64,7 +64,12 @@ const BookingsRequests = ({ bookingConfig }: Props) => {
         <div className="max-w-screen-xl flex flex-col gap-10">
           <Heading level={1}>{t('booking_requests_title')}</Heading>
 
-          <Bookings filter={filter} setPage={setPage} page={page} />
+          <Bookings
+            filter={filter}
+            setPage={setPage}
+            page={page}
+            bookingConfig={bookingConfig}
+          />
         </div>
       </AdminLayout>
     </>

--- a/packages/closer/pages/members/[slug].tsx
+++ b/packages/closer/pages/members/[slug].tsx
@@ -38,7 +38,9 @@ import { useAuth } from '../../contexts/auth';
 import { User, UserLink } from '../../contexts/auth/types';
 import { usePlatform } from '../../contexts/platform';
 import { FinanceApplication } from '../../types';
+import { BookingConfig } from '../../types/api';
 import { GeneralConfig } from '../../types/api';
+import config from '../../configCached';
 import api, { cdn } from '../../utils/api';
 import { getCachedConfig } from '../../utils/cachedConfig.helpers';
 import { getUrlDisplayString } from '../../utils/display.helpers';
@@ -56,9 +58,10 @@ const ConnectedWallet =
 interface MemberPageProps {
   member: User;
   loadError: string;
+  bookingConfig: BookingConfig | null;
 }
 
-const MemberPage = ({ member, loadError }: MemberPageProps) => {
+const MemberPage = ({ member, loadError, bookingConfig }: MemberPageProps) => {
   const generalConfig = getCachedConfig('general') as GeneralConfig | null;
   const t = useTranslations();
   const {
@@ -751,7 +754,11 @@ const MemberPage = ({ member, loadError }: MemberPageProps) => {
                       <h4 className="font-medium text-xl mb-4">
                         {t('members_slug_bookings')}
                       </h4>
-                      <UserBookings user={member} isSpaceHostView={true} />
+                      <UserBookings
+                        user={member}
+                        isSpaceHostView={true}
+                        bookingConfig={bookingConfig ?? undefined}
+                      />
                     </div>
                   )}
 
@@ -1183,13 +1190,14 @@ MemberPage.getInitialProps = async (context: NextPageContext) => {
     });
     return {
       member: res.data.results,
+      bookingConfig: config.booking,
     };
   } catch (err: unknown) {
     console.log('Error', err);
 
     return {
       loadError: parseMessageFromError(err),
-
+      bookingConfig: null,
       };
   }
 };

--- a/packages/closer/pages/stay/[slug]/confirmation.tsx
+++ b/packages/closer/pages/stay/[slug]/confirmation.tsx
@@ -211,7 +211,9 @@ const StayConfirmationPage = ({
       : null;
 
   const options = [
-    stay.doesNeedPickup ? t('stay_create_option_pickup') : null,
+    bookingSettings?.pickUpEnabled && stay.doesNeedPickup
+      ? t('stay_create_option_pickup')
+      : null,
     stay.doesNeedSeparateBeds ? t('stay_create_option_separate_beds') : null,
   ].filter(Boolean);
 

--- a/packages/closer/pages/stay/[slug]/index.tsx
+++ b/packages/closer/pages/stay/[slug]/index.tsx
@@ -1036,7 +1036,9 @@ const StayBookingSummaryPage = ({
               eventName={event?.name}
               volunteerName={volunteer?.name}
               ticketOption={ticketOption?.name}
-              doesNeedPickup={doesNeedPickup}
+              doesNeedPickup={
+                bookingConfig?.pickUpEnabled ? doesNeedPickup : undefined
+              }
               doesNeedSeparateBeds={doesNeedSeparateBeds}
               isEditMode={
                 (canManageBooking || canGuestEditBookingDetails) && isEditMode

--- a/packages/closer/pages/stay/create/stayCheckoutPage.tsx
+++ b/packages/closer/pages/stay/create/stayCheckoutPage.tsx
@@ -1631,40 +1631,45 @@ const StayCheckoutContent = ({
                 </p>
               </div>
             </div>
-            <div className="w-full border-t border-foreground/[0.08] pt-5">
-              <p className="text-sm font-semibold text-gray-900 mb-3">
-                {t('stay_create_options_title')}
-              </p>
-              <div className="flex flex-col gap-3">
-                <Checkbox
-                  isChecked={!!currentStay.doesNeedPickup}
-                  onChange={() =>
-                    handleToggleOption({
-                      doesNeedPickup: !currentStay.doesNeedPickup,
-                    })
-                  }
-                  isEnabled={!isSavingOptions}
-                  id="opt-pickup"
-                >
-                  {t('stay_create_option_pickup')}
-                </Checkbox>
-                {stayBookingGuestCount >= 2 && (
-                  <Checkbox
-                    isChecked={!!currentStay.doesNeedSeparateBeds}
-                    onChange={() =>
-                      handleToggleOption({
-                        doesNeedSeparateBeds:
-                          !currentStay.doesNeedSeparateBeds,
-                      })
-                    }
-                    isEnabled={!isSavingOptions}
-                    id="opt-separate"
-                  >
-                    {t('stay_create_option_separate_beds')}
-                  </Checkbox>
-                )}
+            {(bookingSettings?.pickUpEnabled ||
+              stayBookingGuestCount >= 2) && (
+              <div className="w-full border-t border-foreground/[0.08] pt-5">
+                <p className="text-sm font-semibold text-gray-900 mb-3">
+                  {t('stay_create_options_title')}
+                </p>
+                <div className="flex flex-col gap-3">
+                  {bookingSettings?.pickUpEnabled && (
+                    <Checkbox
+                      isChecked={!!currentStay.doesNeedPickup}
+                      onChange={() =>
+                        handleToggleOption({
+                          doesNeedPickup: !currentStay.doesNeedPickup,
+                        })
+                      }
+                      isEnabled={!isSavingOptions}
+                      id="opt-pickup"
+                    >
+                      {t('stay_create_option_pickup')}
+                    </Checkbox>
+                  )}
+                  {stayBookingGuestCount >= 2 && (
+                    <Checkbox
+                      isChecked={!!currentStay.doesNeedSeparateBeds}
+                      onChange={() =>
+                        handleToggleOption({
+                          doesNeedSeparateBeds:
+                            !currentStay.doesNeedSeparateBeds,
+                        })
+                      }
+                      isEnabled={!isSavingOptions}
+                      id="opt-separate"
+                    >
+                      {t('stay_create_option_separate_beds')}
+                    </Checkbox>
+                  )}
+                </div>
               </div>
-            </div>
+            )}
           </div>
         </BookingSurface>
 


### PR DESCRIPTION
Ops tickets **#1** (guest booking flow) and **#2** (admin dashboard), combined — they are one config gate and reviewing them separately made the completeness claim impossible to check.

`booking.pickUpEnabled` is **already `false` in production**, but station-pickup UI still rendered because several sites never read the flag. This gates all of them. Display-only: `doesNeedPickup` is still written, read and stored everywhere.

## Sites gated

**Guest-facing (#1)**
- `pages/stay/create/stayCheckoutPage.tsx` — the `opt-pickup` checkbox, plus the enclosing options block so a bare "Options" heading doesn't render when both children are hidden
- `pages/stay/[slug]/confirmation.tsx` — options summary line

**Admin (#2)**
- `pages/bookings/[slug]/index.tsx`, `pages/stay/[slug]/index.tsx` — pass `undefined` into the shared `SummaryDates`, which already renders only when `doesNeedPickup !== undefined`
- `components/BookingListPreview/BookingListPreview.tsx` — pickup chip
- `components/Bookings.tsx` — CSV export column
- `components/CurrentBooking.js` — Pickup column on `/bookings/current`
- wiring: `pages/bookings/all.tsx`, `pages/bookings/requests.tsx`, `pages/members/[slug].tsx`

## Two sites found only after the first review passed

Worth calling out, because the process nearly shipped them:

**`components/CurrentBooking.js`** was rendering a Pickup column with 🚗 icons **live in production** with the flag off. Three independent completeness greps — author, reviewer, and mine — all missed it because it is a **`.js`** file and every search was scoped to `*.tsx`/`*.ts`. It was caught by loading the page in a browser with a space-host account. `packages/closer/components` contains untyped legacy `.js`; searches here must not assume TypeScript.

**`pages/members/[slug].tsx`** rendered `<UserBookings>` without `bookingConfig`, so on the space-host view of a member profile the pickup chip was hidden because the config was `undefined`, not because the flag was off. Harmless today, but pickup would have failed to reappear there if the flag were ever re-enabled. (The same page still loses `bookingConfig?.chatLink` for an unrelated reason — not fixed here.)

## Test

`components/pickupGating.test.ts` asserts that every file under `components/` and `pages/` referencing `doesNeedPickup` also reads `pickUpEnabled`, scanning **all** code extensions.

Structural rather than per-component render tests on purpose: the failure mode was not broken logic, it was a render site nobody knew existed, and render tests only cover components you already thought of. Two files are explicitly allowlisted with justifications — `accomodation.tsx` (data-only, renders nothing) and `SummaryDates.tsx` (gated by caller contract).

**Verified the test actually fails on the pre-fix code**, naming `components/CurrentBooking.js` as the offender.

## Verification

- `jest` `packages/closer` — 11 suites, 130 pass / 8 skipped
- `jest` `apps/tdf` — 18 suites, 45 pass
- `tsc --noEmit` — 249 vs a **246 baseline on `develop`**. The +3 are all in the new test file and are the same pre-existing chai/jest global collision (`tsconfig.json` pulls `apps/tdf/cypress.config.ts` into scope) that already affects every test file. **Zero errors in any source file.**
- Full-extension sweep for `doesNeedPickup|pickUpEnabled|opt-pickup`: every remaining reference is either gated, data-only, or a type/config declaration.
- No `yarn.lock`, no `tsconfig.tsbuildinfo`, no generated artifacts in the diff.

## For reviewers / ops

**The flag is build-time, not runtime.** It resolves through `generated/appConfig.snapshot.json`, a Turborepo build output. Flipping `pickUpEnabled` in the admin config screen takes effect only after a rebuild and redeploy. This matches how `checkinTime`, `foodOptionEnabled` etc. already behave, but ticket #2 asks for an admin toggle, so expectations are worth setting. The current snapshot omits `pickUpEnabled` entirely, so it resolves to the `false` default.

**Pre-existing, not touched:** `components/Bookings.tsx` builds CSV rows positionally via `Object.values(row)` with no quoting or escaping, so any value containing a comma already shifts columns, and there is no CSV-injection guard. This PR keeps header and row spreads index-aligned in both flag states, but `headers.map((h) => row[h.key])` would make that alignment structural rather than incidental.
