### PR TITLE
fix(config): resolve booking config at runtime so admin settings apply without a redeploy

### DIFF
--- a/packages/closer/hooks/index.ts
+++ b/packages/closer/hooks/index.ts
@@ -6,6 +6,7 @@ export { useDebounce } from './useDebounce';
 export { useFaqs } from './useFaqs';
 export { useHasMounted } from './useHasMounted';
 export { useInteractionIsHuman } from './useInteractionIsHuman';
+export { useLiveBookingConfig } from './useLiveBookingConfig';
 export { useLocalStorage } from './useLocalStorage';
 export { useNavigationMetrics } from './useNavigationMetrics';
 export { useOutsideClick } from './useOutsideClick';

--- a/packages/closer/hooks/useLiveBookingConfig.integration.test.tsx
+++ b/packages/closer/hooks/useLiveBookingConfig.integration.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { fromJS } from 'immutable';
+
+import { useLiveBookingConfig } from './useLiveBookingConfig';
+
+/**
+ * Regression test for the read-after-dispatch race.
+ *
+ * The first implementation of this hook awaited `platform.config.getOne(...)`
+ * and then read the value back out of the store via `platform.config.findOne`.
+ * That can never work: `findOne` reads `stateRef.current`, which the provider
+ * assigns in its render body (`contexts/platform/platform.js:311-312,322`),
+ * whereas `getOne` dispatches inside a `.then()` (`:384`). The await
+ * continuation is a microtask; React's re-render is a macrotask. So the store
+ * is always still empty at that point and the live value was never applied —
+ * the page fired an extra uncached request and rendered the stale snapshot.
+ *
+ * These tests therefore model exactly that condition: `getOne` resolves with a
+ * populated action while `findOne` returns `undefined`, as it does in a real
+ * provider. Any implementation that reads through the store fails here.
+ */
+
+const mockAuth: { isAuthenticated: boolean } = { isAuthenticated: true };
+jest.mock('../contexts/auth', () => ({
+  useAuth: () => mockAuth,
+}));
+
+const getOne = jest.fn();
+const findOne = jest.fn();
+
+/**
+ * The context value is built once and reused, mirroring the real provider,
+ * where `platform` is a `useMemo(..., [])` (`platform.js:941`). That stability
+ * matters: the hook's effect keys on `platform`, so a stub that returned a
+ * fresh object per render would re-fire the fetch on every render and mask the
+ * once-per-mount guarantee this test exists to pin.
+ */
+const platformValue = { platform: { config: { getOne, findOne } } };
+jest.mock('../contexts/platform', () => ({
+  usePlatform: () => platformValue,
+}));
+
+/** Defaults-merged snapshot, as `configCached` hands it to a page. */
+const SNAPSHOT = { enabled: true, pickUpEnabled: true, minDuration: 1 };
+
+/** The action `getOne` resolves with — `results` is an Immutable Map. */
+const successAction = (value: Record<string, unknown>) => ({
+  type: 'GET_ONE_SUCCESS',
+  id: 'booking',
+  model: 'config',
+  results: fromJS({ _id: 'booking', slug: 'booking', value }),
+});
+
+const Probe = () => {
+  const bookingConfig = useLiveBookingConfig(SNAPSHOT);
+  return (
+    <div>
+      <span data-testid="pickup">{String(bookingConfig?.pickUpEnabled)}</span>
+      <span data-testid="enabled">{String(bookingConfig?.enabled)}</span>
+      <span data-testid="minDuration">
+        {String(bookingConfig?.minDuration)}
+      </span>
+    </div>
+  );
+};
+
+describe('useLiveBookingConfig — does not read back through the store', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.isAuthenticated = true;
+    // Exactly what a real provider does on the awaited continuation: the
+    // reducer has not committed yet, so the store read misses.
+    findOne.mockReturnValue(undefined);
+    getOne.mockResolvedValue(
+      successAction({ enabled: true, pickUpEnabled: false, minDuration: 10 }),
+    );
+  });
+
+  it('applies the live value even though the store is still empty', async () => {
+    render(<Probe />);
+
+    // No flicker: the snapshot renders synchronously on first paint.
+    expect(screen.getByTestId('pickup')).toHaveTextContent('true');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pickup')).toHaveTextContent('false'),
+    );
+    expect(screen.getByTestId('enabled')).toHaveTextContent('true');
+    expect(screen.getByTestId('minDuration')).toHaveTextContent('10');
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('requests the booking slug once, bypassing the store cache', async () => {
+    render(<Probe />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pickup')).toHaveTextContent('false'),
+    );
+    expect(getOne).toHaveBeenCalledTimes(1);
+    expect(getOne).toHaveBeenCalledWith('booking', { force: true });
+  });
+
+  it('keeps the snapshot when the request rejects', async () => {
+    getOne.mockRejectedValue(new Error('503'));
+
+    render(<Probe />);
+
+    await waitFor(() => expect(getOne).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByTestId('pickup')).toHaveTextContent('true'),
+    );
+    expect(screen.getByTestId('enabled')).toHaveTextContent('true');
+    expect(screen.getByTestId('minDuration')).toHaveTextContent('1');
+  });
+
+  it('keeps the snapshot when the error path resolves without results', async () => {
+    // `getOne`'s `.catch` returns `dispatch(...)`, which has no `results` — so
+    // a failure surfaces as a resolved action, not a rejection.
+    getOne.mockResolvedValue({ type: 'GET_ONE_ERROR', error: new Error('x') });
+
+    render(<Probe />);
+
+    await waitFor(() => expect(getOne).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByTestId('pickup')).toHaveTextContent('true'),
+    );
+    expect(screen.getByTestId('minDuration')).toHaveTextContent('1');
+  });
+
+  it('keeps the snapshot when the live doc has an empty value', async () => {
+    // An empty value merged over defaults would yield `enabled: false` and
+    // blank every page behind FeatureNotEnabled.
+    getOne.mockResolvedValue(successAction({}));
+
+    render(<Probe />);
+
+    await waitFor(() => expect(getOne).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByTestId('enabled')).toHaveTextContent('true'),
+    );
+    expect(screen.getByTestId('pickup')).toHaveTextContent('true');
+  });
+
+  it('adds no request for unauthenticated visitors', async () => {
+    mockAuth.isAuthenticated = false;
+
+    render(<Probe />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('pickup')).toHaveTextContent('true'),
+    );
+    expect(getOne).not.toHaveBeenCalled();
+  });
+});

--- a/packages/closer/hooks/useLiveBookingConfig.test.tsx
+++ b/packages/closer/hooks/useLiveBookingConfig.test.tsx
@@ -174,6 +174,29 @@ describe('useLiveBookingConfig', () => {
       await waitFor(() => expect(result.current.checkinTime).not.toBe(18));
     });
 
+    it('reads the doc from the wrapper on a cache hit', async () => {
+      // `getOne`'s cache path resolves with the store wrapper
+      // (`{data, loading, error, receivedAt}`) rather than the document, so the
+      // value sits one level down. Unreachable while `force: true` is passed,
+      // but pinned so dropping that flag cannot silently disable the feature.
+      mockPlatform.config.getOne = jest.fn().mockResolvedValue({
+        type: 'GET_ONE_SUCCESS',
+        fromCache: true,
+        results: fromJS({
+          data: {
+            _id: 'booking',
+            slug: 'booking',
+            value: { pickUpEnabled: false },
+          },
+          loading: false,
+        }),
+      });
+
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+
+      await waitFor(() => expect(result.current.pickUpEnabled).toBe(false));
+    });
+
     it('forces the request past the platform cache', async () => {
       renderHook(() => useLiveBookingConfig(SNAPSHOT));
       await waitFor(() =>

--- a/packages/closer/hooks/useLiveBookingConfig.test.tsx
+++ b/packages/closer/hooks/useLiveBookingConfig.test.tsx
@@ -25,9 +25,18 @@ const SNAPSHOT = {
   minDuration: 1,
 };
 
-/** What the platform store holds: the *raw* API doc, wrapped in Immutable. */
-const immutableDoc = (value: Record<string, unknown>) =>
-  fromJS({ slug: 'booking', value });
+/**
+ * What `getOne` resolves with: the dispatched `GET_ONE_SUCCESS` action, whose
+ * `results` is the *raw* API doc wrapped in Immutable. The hook reads the value
+ * from here rather than from the store — see the note in the hook for why a
+ * store read can never work on the awaited continuation.
+ */
+const successAction = (value: Record<string, unknown>) => ({
+  type: 'GET_ONE_SUCCESS',
+  id: 'booking',
+  model: 'config',
+  results: fromJS({ _id: 'booking', slug: 'booking', value }),
+});
 
 describe('useLiveBookingConfig', () => {
   beforeEach(() => {
@@ -53,8 +62,8 @@ describe('useLiveBookingConfig', () => {
       expect(mockPlatform.config.findOne).not.toHaveBeenCalled();
     });
 
-    it('keeps the snapshot when the fetch succeeds but no doc lands in the store', async () => {
-      mockPlatform.config.findOne = jest.fn().mockReturnValue(undefined);
+    it('keeps the snapshot when the fetch resolves without an action', async () => {
+      mockPlatform.config.getOne = jest.fn().mockResolvedValue(undefined);
 
       const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
 
@@ -65,7 +74,9 @@ describe('useLiveBookingConfig', () => {
     });
 
     it('keeps the snapshot when the live doc has an empty value', async () => {
-      mockPlatform.config.findOne = jest.fn().mockReturnValue(immutableDoc({}));
+      mockPlatform.config.getOne = jest
+        .fn()
+        .mockResolvedValue(successAction({}));
 
       const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
 
@@ -77,9 +88,13 @@ describe('useLiveBookingConfig', () => {
       expect(result.current).toEqual(SNAPSHOT);
     });
 
-    it('keeps the snapshot when reading the store throws', async () => {
-      mockPlatform.config.findOne = jest.fn(() => {
-        throw new Error('store shape changed');
+    it('keeps the snapshot when unwrapping the action throws', async () => {
+      mockPlatform.config.getOne = jest.fn().mockResolvedValue({
+        results: {
+          get: () => {
+            throw new Error('action shape changed');
+          },
+        },
       });
 
       const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
@@ -128,15 +143,13 @@ describe('useLiveBookingConfig', () => {
 
   describe('applying the live value', () => {
     it('overlays the live doc and reflects a flipped toggle', async () => {
-      mockPlatform.config.findOne = jest
-        .fn()
-        .mockReturnValue(
-          immutableDoc({
-            enabled: true,
-            pickUpEnabled: false,
-            minDuration: 10,
-          }),
-        );
+      mockPlatform.config.getOne = jest.fn().mockResolvedValue(
+        successAction({
+          enabled: true,
+          pickUpEnabled: false,
+          minDuration: 10,
+        }),
+      );
 
       const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
 
@@ -149,14 +162,14 @@ describe('useLiveBookingConfig', () => {
     it('fills unset keys from the config defaults, not from the stale snapshot', async () => {
       // `checkinTime` is absent from the live doc; the defaults-merge must
       // supply it rather than leaving the snapshot's value in place.
-      mockPlatform.config.findOne = jest
+      mockPlatform.config.getOne = jest
         .fn()
-        .mockReturnValue(immutableDoc({ enabled: true }));
+        .mockResolvedValue(successAction({ enabled: true }));
 
       const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
 
       await waitFor(() =>
-        expect(mockPlatform.config.findOne).toHaveBeenCalled(),
+        expect(mockPlatform.config.getOne).toHaveBeenCalled(),
       );
       await waitFor(() => expect(result.current.checkinTime).not.toBe(18));
     });

--- a/packages/closer/hooks/useLiveBookingConfig.test.tsx
+++ b/packages/closer/hooks/useLiveBookingConfig.test.tsx
@@ -1,0 +1,187 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { fromJS } from 'immutable';
+
+import { useLiveBookingConfig } from './useLiveBookingConfig';
+
+const mockPlatform: any = { config: { getOne: jest.fn(), findOne: jest.fn() } };
+const mockAuth: { isAuthenticated: boolean } = { isAuthenticated: true };
+
+jest.mock('../contexts/platform', () => ({
+  usePlatform: () => ({ platform: mockPlatform }),
+}));
+
+jest.mock('../contexts/auth', () => ({
+  useAuth: () => mockAuth,
+}));
+
+/**
+ * `configCached` values are defaults-merged, so the snapshot a page holds
+ * always has every key. Only a couple matter here.
+ */
+const SNAPSHOT = {
+  enabled: true,
+  pickUpEnabled: true,
+  checkinTime: 18,
+  minDuration: 1,
+};
+
+/** What the platform store holds: the *raw* API doc, wrapped in Immutable. */
+const immutableDoc = (value: Record<string, unknown>) =>
+  fromJS({ slug: 'booking', value });
+
+describe('useLiveBookingConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.isAuthenticated = true;
+    mockPlatform.config.getOne = jest.fn().mockResolvedValue(undefined);
+    mockPlatform.config.findOne = jest.fn().mockReturnValue(undefined);
+  });
+
+  describe('fallback to the build-time snapshot', () => {
+    it('keeps the snapshot when the config fetch rejects', async () => {
+      mockPlatform.config.getOne = jest
+        .fn()
+        .mockRejectedValue(new Error('config service down'));
+
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+
+      expect(result.current).toEqual(SNAPSHOT);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current).toEqual(SNAPSHOT);
+      expect(mockPlatform.config.findOne).not.toHaveBeenCalled();
+    });
+
+    it('keeps the snapshot when the fetch succeeds but no doc lands in the store', async () => {
+      mockPlatform.config.findOne = jest.fn().mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current).toEqual(SNAPSHOT);
+    });
+
+    it('keeps the snapshot when the live doc has an empty value', async () => {
+      mockPlatform.config.findOne = jest.fn().mockReturnValue(immutableDoc({}));
+
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      // An empty live value merged over defaults would yield `enabled: false`
+      // and blank the page. It must be ignored.
+      expect(result.current).toEqual(SNAPSHOT);
+    });
+
+    it('keeps the snapshot when reading the store throws', async () => {
+      mockPlatform.config.findOne = jest.fn(() => {
+        throw new Error('store shape changed');
+      });
+
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current).toEqual(SNAPSHOT);
+    });
+
+    it('survives a platform context without a config model', async () => {
+      const { result } = renderHook(() => {
+        const saved = mockPlatform.config;
+        mockPlatform.config = undefined;
+        const value = useLiveBookingConfig(SNAPSHOT);
+        mockPlatform.config = saved;
+        return value;
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current).toEqual(SNAPSHOT);
+    });
+
+    it('passes a null snapshot straight through when the fetch fails', async () => {
+      mockPlatform.config.getOne = jest.fn().mockRejectedValue(new Error('x'));
+
+      const { result } = renderHook(() =>
+        useLiveBookingConfig<null | Record<string, unknown>>(null),
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current).toBeNull();
+    });
+  });
+
+  describe('no flicker on render-gating values', () => {
+    it('returns the snapshot synchronously on first render', () => {
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+      expect(result.current.enabled).toBe(true);
+    });
+  });
+
+  describe('applying the live value', () => {
+    it('overlays the live doc and reflects a flipped toggle', async () => {
+      mockPlatform.config.findOne = jest
+        .fn()
+        .mockReturnValue(
+          immutableDoc({
+            enabled: true,
+            pickUpEnabled: false,
+            minDuration: 10,
+          }),
+        );
+
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+
+      expect(result.current.pickUpEnabled).toBe(true);
+      await waitFor(() => expect(result.current.pickUpEnabled).toBe(false));
+      expect(result.current.enabled).toBe(true);
+      expect(result.current.minDuration).toBe(10);
+    });
+
+    it('fills unset keys from the config defaults, not from the stale snapshot', async () => {
+      // `checkinTime` is absent from the live doc; the defaults-merge must
+      // supply it rather than leaving the snapshot's value in place.
+      mockPlatform.config.findOne = jest
+        .fn()
+        .mockReturnValue(immutableDoc({ enabled: true }));
+
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+
+      await waitFor(() =>
+        expect(mockPlatform.config.findOne).toHaveBeenCalled(),
+      );
+      await waitFor(() => expect(result.current.checkinTime).not.toBe(18));
+    });
+
+    it('forces the request past the platform cache', async () => {
+      renderHook(() => useLiveBookingConfig(SNAPSHOT));
+      await waitFor(() =>
+        expect(mockPlatform.config.getOne).toHaveBeenCalledWith('booking', {
+          force: true,
+        }),
+      );
+    });
+  });
+
+  describe('guest page loads', () => {
+    it('adds no config request when the visitor is unauthenticated', async () => {
+      mockAuth.isAuthenticated = false;
+
+      const { result } = renderHook(() => useLiveBookingConfig(SNAPSHOT));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockPlatform.config.getOne).not.toHaveBeenCalled();
+      expect(result.current).toEqual(SNAPSHOT);
+    });
+  });
+});

--- a/packages/closer/hooks/useLiveBookingConfig.ts
+++ b/packages/closer/hooks/useLiveBookingConfig.ts
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { configDescription } from '../config';
+import { useAuth } from '../contexts/auth';
+import { usePlatform } from '../contexts/platform';
+import { getDefaultConfigValue } from '../utils/config.utils';
+
+export const BOOKING_CONFIG_SLUG = 'booking';
+
+/**
+ * `configCached` is a build-time snapshot committed to git
+ * (`generated/appConfig.snapshot.json`). Anything read from it only changes on
+ * a rebuild + redeploy, so a toggle flipped in `/admin/config` is invisible to
+ * the running site. This hook layers the live `booking` config document on top
+ * of that snapshot at runtime.
+ *
+ * Two properties are load-bearing and must not be regressed:
+ *
+ * 1. The snapshot is always the fallback. A failed, slow, or empty fetch leaves
+ *    the caller with exactly the value it renders today — a config outage must
+ *    never blank or crash a page.
+ * 2. There is no "loading" state. The snapshot value is returned synchronously
+ *    on first render, so values that gate rendering (`enabled`) never flicker
+ *    through a falsy intermediate.
+ *
+ * The fetch is gated on an authenticated session so that unauthenticated guest
+ * page loads do not gain an extra request.
+ */
+
+type LiveConfigValue = Record<string, unknown>;
+
+const isNonEmptyObject = (value: unknown): value is LiveConfigValue =>
+  value != null &&
+  typeof value === 'object' &&
+  !Array.isArray(value) &&
+  Object.keys(value as object).length > 0;
+
+/**
+ * The platform store holds the *raw* API document, whereas `configCached`
+ * exposes defaults-merged values (see `buildMergedConfig`). Merging the live
+ * value over `getDefaultConfigValue` reproduces what a rebuild would have
+ * produced, rather than handing callers a document missing every key ops never
+ * explicitly set (`enabled` among them, whose default is `false`).
+ */
+export const mergeLiveBookingConfig = <T>(
+  cachedConfig: T,
+  liveValue: unknown,
+): T => {
+  if (!isNonEmptyObject(liveValue)) return cachedConfig;
+  const defaults = getDefaultConfigValue(
+    BOOKING_CONFIG_SLUG,
+    configDescription as any[],
+  );
+  return { ...defaults, ...liveValue } as T;
+};
+
+/** Reads the booking doc out of the platform store, unwrapping Immutable. */
+export const readBookingConfigFromPlatform = (platform: any): unknown => {
+  try {
+    const doc = platform?.config?.findOne?.(BOOKING_CONFIG_SLUG);
+    const value = doc?.get?.('value');
+    if (value == null) return null;
+    return typeof value?.toJS === 'function' ? value.toJS() : value;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Fetches the live `booking` config once per mount and merges it over the
+ * build-time snapshot the caller already has. Returns the snapshot unchanged
+ * until (and unless) a usable live value arrives.
+ */
+export const useLiveBookingConfig = <T>(cachedConfig: T): T => {
+  const { platform } = usePlatform() as { platform: any };
+  const { isAuthenticated } = useAuth();
+  const [liveValue, setLiveValue] = useState<LiveConfigValue | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        await platform?.config?.getOne?.(BOOKING_CONFIG_SLUG, { force: true });
+      } catch {
+        // Keep the snapshot — a config outage must not change what renders.
+        return;
+      }
+      if (cancelled) return;
+      const raw = readBookingConfigFromPlatform(platform);
+      if (isNonEmptyObject(raw)) setLiveValue(raw);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [platform, isAuthenticated]);
+
+  return useMemo(
+    () => mergeLiveBookingConfig(cachedConfig, liveValue),
+    [cachedConfig, liveValue],
+  );
+};
+
+export default useLiveBookingConfig;

--- a/packages/closer/hooks/useLiveBookingConfig.ts
+++ b/packages/closer/hooks/useLiveBookingConfig.ts
@@ -70,8 +70,17 @@ export const readBookingConfigFromAction = (action: any): unknown => {
   try {
     const results = action?.results;
     if (results == null) return null;
-    const value =
-      typeof results.get === 'function' ? results.get('value') : results.value;
+    const read = (source: any, key: string) =>
+      typeof source?.get === 'function' ? source.get(key) : source?.[key];
+
+    // `results` is the document itself on the network path
+    // (`fromJS(res.data.results)`), but on the cache-hit path it is the store
+    // *wrapper* — `{ data, loading, error, receivedAt }` — so the document sits
+    // one level down under `data`. Passing `force: true` means the cache path is
+    // unreachable today; handling it anyway keeps this from silently returning
+    // null if that flag is ever dropped as an optimisation.
+    const doc = action?.fromCache ? read(results, 'data') : results;
+    const value = read(doc, 'value');
     if (value == null) return null;
     return typeof value?.toJS === 'function' ? value.toJS() : value;
   } catch {

--- a/packages/closer/hooks/useLiveBookingConfig.ts
+++ b/packages/closer/hooks/useLiveBookingConfig.ts
@@ -54,11 +54,24 @@ export const mergeLiveBookingConfig = <T>(
   return { ...defaults, ...liveValue } as T;
 };
 
-/** Reads the booking doc out of the platform store, unwrapping Immutable. */
-export const readBookingConfigFromPlatform = (platform: any): unknown => {
+/**
+ * Reads the booking value out of the action `getOne` resolves with.
+ *
+ * It must come from the action, NOT from `platform.config.findOne`. `findOne`
+ * reads `stateRef.current` (`contexts/platform/platform.js:322`), which the
+ * provider assigns in its *render body* (`:311-312`), while `getOne` dispatches
+ * `GET_ONE_SUCCESS` inside a `.then()` (`:384`). The await continuation here is
+ * a microtask and React's re-render is a macrotask, so a store read immediately
+ * after awaiting is guaranteed to miss and this hook would silently never apply
+ * the live value. `getOne` returns the dispatched action (`:377-385`), so the
+ * data is already in hand and no re-render has to have happened.
+ */
+export const readBookingConfigFromAction = (action: any): unknown => {
   try {
-    const doc = platform?.config?.findOne?.(BOOKING_CONFIG_SLUG);
-    const value = doc?.get?.('value');
+    const results = action?.results;
+    if (results == null) return null;
+    const value =
+      typeof results.get === 'function' ? results.get('value') : results.value;
     if (value == null) return null;
     return typeof value?.toJS === 'function' ? value.toJS() : value;
   } catch {
@@ -80,14 +93,17 @@ export const useLiveBookingConfig = <T>(cachedConfig: T): T => {
     if (!isAuthenticated) return;
     let cancelled = false;
     (async () => {
+      let action: unknown;
       try {
-        await platform?.config?.getOne?.(BOOKING_CONFIG_SLUG, { force: true });
+        action = await platform?.config?.getOne?.(BOOKING_CONFIG_SLUG, {
+          force: true,
+        });
       } catch {
         // Keep the snapshot — a config outage must not change what renders.
         return;
       }
       if (cancelled) return;
-      const raw = readBookingConfigFromPlatform(platform);
+      const raw = readBookingConfigFromAction(action);
       if (isNonEmptyObject(raw)) setLiveValue(raw);
     })();
     return () => {

--- a/packages/closer/pages/bookings/[slug]/index.tsx
+++ b/packages/closer/pages/bookings/[slug]/index.tsx
@@ -44,6 +44,7 @@ import {
 import type { Stay } from '../../../types/stay';
 import { FoodOption } from '../../../types/food';
 import config from '../../../configCached';
+import { useLiveBookingConfig } from '../../../hooks/useLiveBookingConfig';
 import { useBookingLinkedCharges } from '../../../hooks/useBookingLinkedCharges';
 import api from '../../../utils/api';
 import { mergeBookingLedgerCharges } from '../../../utils/bookingChargesLedger.helpers';
@@ -105,7 +106,7 @@ const BookingPage = ({
   volunteer,
   error,
   bookingCreatedBy,
-  bookingConfig,
+  bookingConfig: cachedBookingConfig,
   listings,
   generalConfig,
   paymentConfig,
@@ -114,6 +115,7 @@ const BookingPage = ({
   const t = useTranslations();
   const router = useRouter();
 
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const config = useConfig();
   const { timeZone } = generalConfig || { timeZone: config.DEFAULT_TIMEZONE };
   const isBookingEnabled =

--- a/packages/closer/pages/bookings/all.tsx
+++ b/packages/closer/pages/bookings/all.tsx
@@ -12,6 +12,7 @@ import { useTranslations } from 'next-intl';
 
 import { useAuth } from '../../contexts/auth';
 import config from '../../configCached';
+import { useLiveBookingConfig } from '../../hooks/useLiveBookingConfig';
 import { parseMessageFromError } from '../../utils/common';
 import FeatureNotEnabled from '../../components/FeatureNotEnabled';
 import PageNotFound from '../not-found';
@@ -20,8 +21,11 @@ interface Props {
   bookingConfig: any;
 }
 
-const AllBookingsRequestsPage = ({ bookingConfig }: Props) => {
+const AllBookingsRequestsPage = ({
+  bookingConfig: cachedBookingConfig,
+}: Props) => {
   const t = useTranslations();
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const isBookingEnabled =
     bookingConfig?.enabled &&
     process.env.NEXT_PUBLIC_FEATURE_BOOKING === 'true';

--- a/packages/closer/pages/bookings/current.tsx
+++ b/packages/closer/pages/bookings/current.tsx
@@ -9,6 +9,7 @@ import { useTranslations } from 'next-intl';
 
 import { useAuth } from '../../contexts/auth';
 import config from '../../configCached';
+import { useLiveBookingConfig } from '../../hooks/useLiveBookingConfig';
 import { parseMessageFromError } from '../../utils/common';
 import FeatureNotEnabled from '../../components/FeatureNotEnabled';
 import PageNotFound from '../not-found';
@@ -17,8 +18,9 @@ interface Props {
   bookingConfig: any;
 }
 
-const CurrentBookings = ({ bookingConfig }: Props) => {
+const CurrentBookings = ({ bookingConfig: cachedBookingConfig }: Props) => {
   const t = useTranslations();
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const isBookingEnabled =
     bookingConfig?.enabled &&
     process.env.NEXT_PUBLIC_FEATURE_BOOKING === 'true';

--- a/packages/closer/pages/bookings/index.tsx
+++ b/packages/closer/pages/bookings/index.tsx
@@ -1,23 +1,25 @@
 import Head from 'next/head';
 
+import FeatureNotEnabled from '../../components/FeatureNotEnabled';
 import UserBookings from '../../components/UserBookings';
 
 import { NextPageContext } from 'next';
 import { useTranslations } from 'next-intl';
 
-import { useAuth } from '../../contexts/auth';
-import { BookingConfig } from '../../types';
 import config from '../../configCached';
+import { useAuth } from '../../contexts/auth';
+import { useLiveBookingConfig } from '../../hooks/useLiveBookingConfig';
+import { BookingConfig } from '../../types';
 import { parseMessageFromError } from '../../utils/common';
-import FeatureNotEnabled from '../../components/FeatureNotEnabled';
 import PageNotFound from '../not-found';
 
 interface Props {
   bookingConfig: BookingConfig;
 }
 
-const BookingsDirectory = ({ bookingConfig }: Props) => {
+const BookingsDirectory = ({ bookingConfig: cachedBookingConfig }: Props) => {
   const t = useTranslations();
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const isBookingEnabled =
     bookingConfig?.enabled &&
     process.env.NEXT_PUBLIC_FEATURE_BOOKING === 'true';
@@ -38,14 +40,17 @@ const BookingsDirectory = ({ bookingConfig }: Props) => {
         <meta name="robots" content="noindex, nofollow" />
       </Head>
 
-      <UserBookings user={user} bookingConfig={bookingConfig} hideExportCsv={true} />
+      <UserBookings
+        user={user}
+        bookingConfig={bookingConfig}
+        hideExportCsv={true}
+      />
     </>
   );
 };
 
 BookingsDirectory.getInitialProps = async (context: NextPageContext) => {
   try {
-
     const bookingConfig = config.booking;
     return {
       bookingConfig,
@@ -54,7 +59,7 @@ BookingsDirectory.getInitialProps = async (context: NextPageContext) => {
     return {
       bookingConfig: null,
       error: parseMessageFromError(err),
-      };
+    };
   }
 };
 

--- a/packages/closer/pages/bookings/requests.tsx
+++ b/packages/closer/pages/bookings/requests.tsx
@@ -12,6 +12,7 @@ import { useTranslations } from 'next-intl';
 
 import { useAuth } from '../../contexts/auth';
 import config from '../../configCached';
+import { useLiveBookingConfig } from '../../hooks/useLiveBookingConfig';
 import { parseMessageFromError } from '../../utils/common';
 import FeatureNotEnabled from '../../components/FeatureNotEnabled';
 import PageNotFound from '../not-found';
@@ -22,8 +23,9 @@ interface Props {
   bookingConfig: any;
 }
 
-const BookingsRequests = ({ bookingConfig }: Props) => {
+const BookingsRequests = ({ bookingConfig: cachedBookingConfig }: Props) => {
   const t = useTranslations();
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const isBookingEnabled =
     bookingConfig?.enabled &&
     process.env.NEXT_PUBLIC_FEATURE_BOOKING === 'true';

--- a/packages/closer/pages/members/[slug].tsx
+++ b/packages/closer/pages/members/[slug].tsx
@@ -41,6 +41,7 @@ import { FinanceApplication } from '../../types';
 import { BookingConfig } from '../../types/api';
 import { GeneralConfig } from '../../types/api';
 import config from '../../configCached';
+import { useLiveBookingConfig } from '../../hooks/useLiveBookingConfig';
 import api, { cdn } from '../../utils/api';
 import { getCachedConfig } from '../../utils/cachedConfig.helpers';
 import { getUrlDisplayString } from '../../utils/display.helpers';
@@ -61,7 +62,12 @@ interface MemberPageProps {
   bookingConfig: BookingConfig | null;
 }
 
-const MemberPage = ({ member, loadError, bookingConfig }: MemberPageProps) => {
+const MemberPage = ({
+  member,
+  loadError,
+  bookingConfig: cachedBookingConfig,
+}: MemberPageProps) => {
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const generalConfig = getCachedConfig('general') as GeneralConfig | null;
   const t = useTranslations();
   const {

--- a/packages/closer/pages/stay/[slug]/confirmation.tsx
+++ b/packages/closer/pages/stay/[slug]/confirmation.tsx
@@ -19,6 +19,7 @@ import { NextPageContext } from 'next';
 import { useTranslations } from 'next-intl';
 
 import config from '../../../configCached';
+import { useLiveBookingConfig } from '../../../hooks/useLiveBookingConfig';
 import { useAuth } from '../../../contexts/auth';
 import { useConfig } from '../../../hooks/useConfig';
 import { useRedirectLegacyListingStayRoute } from '../../../hooks/useRedirectLegacyListingStayRoute';
@@ -42,12 +43,13 @@ interface Props {
 }
 
 const StayConfirmationPage = ({
-  bookingSettings,
+  bookingSettings: cachedBookingSettings,
   generalConfig,
   error,
 }: Props) => {
   const router = useRouter();
   const t = useTranslations();
+  const bookingSettings = useLiveBookingConfig(cachedBookingSettings);
   const { user, isAuthenticated } = useAuth();
   const defaultConfig = useConfig();
   const PLATFORM_NAME =

--- a/packages/closer/pages/stay/[slug]/index.tsx
+++ b/packages/closer/pages/stay/[slug]/index.tsx
@@ -46,6 +46,7 @@ import {
 import type { Stay } from '../../../types/stay';
 import { FoodOption } from '../../../types/food';
 import config from '../../../configCached';
+import { useLiveBookingConfig } from '../../../hooks/useLiveBookingConfig';
 import { useBookingLinkedCharges } from '../../../hooks/useBookingLinkedCharges';
 import api from '../../../utils/api';
 import { mergeBookingLedgerCharges } from '../../../utils/bookingChargesLedger.helpers';
@@ -124,7 +125,7 @@ const StayBookingSummaryPage = ({
   volunteer,
   error,
   bookingCreatedBy,
-  bookingConfig,
+  bookingConfig: cachedBookingConfig,
   listings,
   generalConfig,
   paymentConfig,
@@ -133,6 +134,7 @@ const StayBookingSummaryPage = ({
   const t = useTranslations();
   const router = useRouter();
 
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const config = useConfig();
   const { timeZone } = generalConfig || { timeZone: config.DEFAULT_TIMEZONE };
   const isBookingEnabled =

--- a/packages/closer/pages/stay/create/stayCheckoutPage.tsx
+++ b/packages/closer/pages/stay/create/stayCheckoutPage.tsx
@@ -53,6 +53,7 @@ import { usePlatform } from '../../../contexts/platform';
 import { WalletDispatch, WalletState } from '../../../contexts/wallet';
 import { useBookingSmartContract } from '../../../hooks/useBookingSmartContract';
 import { useConfig } from '../../../hooks/useConfig';
+import { useLiveBookingConfig } from '../../../hooks/useLiveBookingConfig';
 import { useStayCreditsEligibility } from '../../../hooks/useStayCreditsEligibility';
 import {
   BookingSettings,
@@ -197,7 +198,7 @@ interface Props {
 }
 
 const StayCheckoutPage = ({
-  bookingSettings,
+  bookingSettings: cachedBookingSettings,
   generalConfig,
   volunteerConfig,
   foodOptions,
@@ -205,6 +206,7 @@ const StayCheckoutPage = ({
 }: Props) => {
   const router = useRouter();
   const t = useTranslations();
+  const bookingSettings = useLiveBookingConfig(cachedBookingSettings);
   const { user, isAuthenticated } = useAuth();
   const defaultConfig = useConfig();
   const PLATFORM_NAME =

--- a/packages/closer/pages/stay/past.tsx
+++ b/packages/closer/pages/stay/past.tsx
@@ -4,14 +4,15 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import Bookings from '../../components/Bookings';
+import FeatureNotEnabled from '../../components/FeatureNotEnabled';
 
 import { NextPageContext } from 'next';
 import { useTranslations } from 'next-intl';
 
-import FeatureNotEnabled from '../../components/FeatureNotEnabled';
-import { useAuth } from '../../contexts/auth';
-import { BookingConfig } from '../../types';
 import config from '../../configCached';
+import { useAuth } from '../../contexts/auth';
+import { useLiveBookingConfig } from '../../hooks/useLiveBookingConfig';
+import { BookingConfig } from '../../types';
 import { parseMessageFromError } from '../../utils/common';
 import PageNotFound from '../not-found';
 
@@ -21,8 +22,11 @@ interface Props {
 
 const bookingsToShowLimit = 50;
 
-const StayPastBookingsPage = ({ bookingConfig }: Props) => {
+const StayPastBookingsPage = ({
+  bookingConfig: cachedBookingConfig,
+}: Props) => {
   const t = useTranslations();
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const { user } = useAuth();
   const [page, setPage] = useState(1);
 
@@ -98,7 +102,7 @@ StayPastBookingsPage.getInitialProps = async (context: NextPageContext) => {
     return {
       bookingConfig: null,
       error: parseMessageFromError(err),
-      };
+    };
   }
 };
 

--- a/packages/closer/pages/stay/upcoming.tsx
+++ b/packages/closer/pages/stay/upcoming.tsx
@@ -4,14 +4,15 @@ import Link from 'next/link';
 import { useState } from 'react';
 
 import Bookings from '../../components/Bookings';
+import FeatureNotEnabled from '../../components/FeatureNotEnabled';
 
 import { NextPageContext } from 'next';
 import { useTranslations } from 'next-intl';
 
-import FeatureNotEnabled from '../../components/FeatureNotEnabled';
-import { useAuth } from '../../contexts/auth';
-import { BookingConfig } from '../../types';
 import config from '../../configCached';
+import { useAuth } from '../../contexts/auth';
+import { useLiveBookingConfig } from '../../hooks/useLiveBookingConfig';
+import { BookingConfig } from '../../types';
 import { parseMessageFromError } from '../../utils/common';
 import PageNotFound from '../not-found';
 
@@ -21,8 +22,11 @@ interface Props {
 
 const bookingsToShowLimit = 50;
 
-const StayUpcomingBookingsPage = ({ bookingConfig }: Props) => {
+const StayUpcomingBookingsPage = ({
+  bookingConfig: cachedBookingConfig,
+}: Props) => {
   const t = useTranslations();
+  const bookingConfig = useLiveBookingConfig(cachedBookingConfig);
   const { user } = useAuth();
   const [page, setPage] = useState(1);
 
@@ -81,7 +85,9 @@ const StayUpcomingBookingsPage = ({ bookingConfig }: Props) => {
       </Head>
       <div className="mx-auto flex max-w-screen-lg flex-col gap-6 px-4 py-8">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-2xl font-semibold">{t('bookings_upcoming_tab')}</h1>
+          <h1 className="text-2xl font-semibold">
+            {t('bookings_upcoming_tab')}
+          </h1>
           <Link href="/stay/past" className="text-sm text-accent underline">
             {t('past_bookings_title')}
           </Link>
@@ -109,7 +115,7 @@ StayUpcomingBookingsPage.getInitialProps = async (context: NextPageContext) => {
     return {
       bookingConfig: null,
       error: parseMessageFromError(err),
-      };
+    };
   }
 };
 


### PR DESCRIPTION
Closes #914.

## Problem

Booking pages read `bookingConfig` from a **build-time snapshot** (`configCached` → `generated/appConfig.snapshot.json`, tracked in git), so a setting flipped in `/admin/config` does nothing until the site is rebuilt and redeployed.

This is very likely why tasks #1 and #2 on the ground-team list existed at all: ops had **already** set `pickUpEnabled: false`, and the UI ignored it. #913 fixed the pages that never read the flag — but even after it merges, the dashboard toggle still would not take effect without a redeploy.

It is not only pickup. The committed snapshot on `develop` currently disagrees with production:

| Key | Snapshot | Live API |
|---|---|---|
| `booking.pickUpEnabled` | *absent* → falsy | `false` |
| `booking.minDuration` | `1` | `"10"` |
| `volunteering.volunteeringMinStay` | `7` | `"28"` |

## Change

New `hooks/useLiveBookingConfig.ts` fetches the `booking` config slug at runtime and layers it over the snapshot the page already has. Applied to the 11 surfaces that render booking config.

Two properties are load-bearing:

1. **The snapshot is always the fallback.** A failed, empty, or malformed response leaves the page rendering exactly what it does today. A config outage must never blank a page.
2. **No loading state.** The snapshot returns synchronously on first render, so `bookingConfig?.enabled` never flickers through a falsy intermediate into `FeatureNotEnabled`.

The live value is merged over `getDefaultConfigValue('booking')`, reproducing `buildMergedConfig` exactly — the store holds the *raw* document, and `enabled`'s default is `false`, so merging the raw doc alone would blank every page behind `FeatureNotEnabled`.

Fetching is gated on an authenticated session, so unauthenticated page loads gain no extra request.

## Two bugs found in review, both fixed here

**1. The first implementation was a no-op.** It awaited `platform.config.getOne(...)` then read the value back via `platform.config.findOne`. That can never work: `findOne` reads `stateRef.current`, assigned in the provider's *render body* (`contexts/platform/platform.js:311-312,322`), while `getOne` dispatches inside a `.then()` (`:384`). The await continuation is a microtask; React's re-render is a macrotask. So the store read always missed, and every page mount fired an extra uncached request and then rendered the stale snapshot anyway — strictly worse than not fetching.

`getOne` returns the action it dispatched (`:377-385`), so the document is already in hand. It reads from there now.

> Worth a separate look: `pages/admin/config.tsx:285-288` has the same immediate `getOne`-then-`findOne` shape and is likely already broken in production. `pages/admin/rbac.tsx` has it too but works by accident — it awaits three sequential requests, so React has flushed a render before its final `findOne`.

**2. Three pages were missed.** `pages/stay/upcoming.tsx`, `pages/stay/past.tsx` and `pages/bookings/index.tsx` render the pickup-gated components but already had the `bookingConfig` prop wired, so #913 never touched them. Without this, ops flipping the toggle would see the pickup badge and CSV column vanish on `/bookings/all` but persist on `/stay/upcoming` **in the same session**. `pickupGating.test.ts` cannot catch that — it scans for the literal `doesNeedPickup`, which these pages never mention.

## Testing

18 tests across two files. The first round's tests stubbed `platform.config` wholesale and so passed green against provably dead code; both files now model the real condition — `getOne` resolves with a populated action while `findOne` returns `undefined` — and assert `findOne` is never called.

Every test was verified to **fail** against the implementation it guards:
- 4 tests fail against the pre-fix hook
- the cache-hit test fails without its fix

Mutation-tested by the reviewer: nulling the action read, removing the auth gate, dropping `force: true`, and merging over the snapshot instead of the defaults each turn the suite red.

`yarn test`: 7/7 turbo tasks, 148 + 45 passing. ESLint clean. tsc: 288 total against a 249 baseline; all 39 new are the pre-existing chai-vs-jest `Assertion` collision in test files, **zero in source**.

## Known scope gaps (follow-ups, noted on #914)

- `pages/bookings/create/dates.tsx:318,370` enforces `minDuration` and `volunteeringMinStay` — the two most-drifted values — from the snapshot. Guest-facing booking path; deserves its own review.
- `pages/stay/create/stayListingBookPage.tsx:679,948` likewise for `pickUpEnabled`.
- Build correctness (Part 2 of #914): `turbo.json`'s `build:config` declares its inputs as only two script files, so a deploy that changes neither gets a cache hit and skips the refetch; `syncBuildConfig.cjs` exits 0 silently when `NEXT_PUBLIC_API_URL` is unset. Until that is fixed the committed snapshot keeps drifting.

## Merge order

Stacked on #913 (`fix/disable-station-pickup`) — **merge #913 first**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Booking and stay pages now use the latest available booking configuration while retaining cached settings as a fallback.
  * Configuration updates are applied without intermediate loading states.
  * Pickup-related options and summaries now reflect whether pickup is enabled.

* **Bug Fixes**
  * Improved handling of unavailable, empty, or failed configuration requests.
  * Unauthenticated visitors no longer trigger unnecessary booking configuration requests.

* **Tests**
  * Added comprehensive coverage for live configuration loading, fallback behavior, caching, errors, and authentication states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->