### PR TITLE
fix(build): retry config fetch with backoff + CONFIG_BUILD_API_URL override

### DIFF
--- a/packages/closer/scripts/__tests__/syncBuildConfig.test.js
+++ b/packages/closer/scripts/__tests__/syncBuildConfig.test.js
@@ -1,6 +1,7 @@
 const {
   fetchWithRetry,
   resolveConfigApiUrl,
+  FETCH_TIMEOUT_MS,
   MAX_ATTEMPTS,
   RETRY_DELAYS_MS,
 } = require('../syncBuildConfig.cjs');
@@ -62,6 +63,45 @@ describe('fetchWithRetry', () => {
     expect(res.ok).toBe(true);
     expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(instantSleep.mock.calls.map(([ms]) => ms)).toEqual([2000, 4000]);
+  });
+
+  it('retries timeouts (AbortError) like other network errors and reports the timeout duration', async () => {
+    const abortError = () => {
+      const err = new Error('This operation was aborted');
+      err.name = 'AbortError';
+      return err;
+    };
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValueOnce(abortError())
+      .mockRejectedValueOnce(abortError())
+      .mockResolvedValue(okResponse());
+    const res = await fetchWithRetry(URL, {
+      fetchImpl,
+      sleep: instantSleep,
+      log: silentLog,
+    });
+    expect(res.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(instantSleep.mock.calls.map(([ms]) => ms)).toEqual([2000, 4000]);
+    expect(silentLog.warn.mock.calls[0][0]).toContain(
+      `timed out after ${FETCH_TIMEOUT_MS}ms`,
+    );
+  });
+
+  it('reports the timeout in the final error when every attempt aborts', async () => {
+    const fetchImpl = jest.fn().mockImplementation(() => {
+      const err = new Error('This operation was aborted');
+      err.name = 'AbortError';
+      return Promise.reject(err);
+    });
+    await expect(
+      fetchWithRetry(URL, { fetchImpl, sleep: instantSleep, log: silentLog }),
+    ).rejects.toThrow(
+      `Config API unreachable after ${MAX_ATTEMPTS} attempts (timed out after ${FETCH_TIMEOUT_MS}ms)`,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+    expect(instantSleep.mock.calls.map(([ms]) => ms)).toEqual(RETRY_DELAYS_MS);
   });
 
   it('retries non-200 responses and succeeds', async () => {

--- a/packages/closer/scripts/__tests__/syncBuildConfig.test.js
+++ b/packages/closer/scripts/__tests__/syncBuildConfig.test.js
@@ -1,0 +1,120 @@
+const {
+  fetchWithRetry,
+  MAX_ATTEMPTS,
+  RETRY_DELAYS_MS,
+} = require('../syncBuildConfig.cjs');
+
+const URL = 'https://api.example.closer.earth/config?limit=500';
+
+const silentLog = { warn: jest.fn(), error: jest.fn(), log: jest.fn() };
+const instantSleep = jest.fn(() => Promise.resolve());
+
+const okResponse = () => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  text: async () => '',
+  json: async () => ({ results: [] }),
+});
+
+const errorResponse = (status, statusText, body = '') => ({
+  ok: false,
+  status,
+  statusText,
+  text: async () => body,
+});
+
+const networkError = (code) => {
+  const err = new TypeError('fetch failed');
+  err.cause = { code, message: 'network trouble' };
+  return err;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('fetchWithRetry', () => {
+  it('returns the response on first success without retrying', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue(okResponse());
+    const res = await fetchWithRetry(URL, {
+      fetchImpl,
+      sleep: instantSleep,
+      log: silentLog,
+    });
+    expect(res.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(instantSleep).not.toHaveBeenCalled();
+  });
+
+  it('retries network errors with 2/4/8/16s backoff and succeeds', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValueOnce(networkError('ENETUNREACH'))
+      .mockRejectedValueOnce(networkError('ENETUNREACH'))
+      .mockResolvedValue(okResponse());
+    const res = await fetchWithRetry(URL, {
+      fetchImpl,
+      sleep: instantSleep,
+      log: silentLog,
+    });
+    expect(res.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(instantSleep.mock.calls.map(([ms]) => ms)).toEqual([2000, 4000]);
+  });
+
+  it('retries non-200 responses and succeeds', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(errorResponse(503, 'Service Unavailable'))
+      .mockResolvedValue(okResponse());
+    const res = await fetchWithRetry(URL, {
+      fetchImpl,
+      sleep: instantSleep,
+      log: silentLog,
+    });
+    expect(res.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports "unreachable after N attempts" when every attempt is a network error', async () => {
+    const fetchImpl = jest.fn().mockRejectedValue(networkError('ENETUNREACH'));
+    await expect(
+      fetchWithRetry(URL, { fetchImpl, sleep: instantSleep, log: silentLog }),
+    ).rejects.toThrow(
+      `Config API unreachable after ${MAX_ATTEMPTS} attempts (ENETUNREACH: network trouble)`,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+    expect(instantSleep.mock.calls.map(([ms]) => ms)).toEqual(RETRY_DELAYS_MS);
+  });
+
+  it('reports the HTTP status when every attempt gets a non-200', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(errorResponse(502, 'Bad Gateway', 'upstream down'));
+    await expect(
+      fetchWithRetry(URL, { fetchImpl, sleep: instantSleep, log: silentLog }),
+    ).rejects.toThrow(
+      `Config request failed after ${MAX_ATTEMPTS} attempts: HTTP 502 Bad Gateway`,
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+  });
+
+  it('classifies the failure by the last attempt (network error after HTTP errors)', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(errorResponse(500, 'Internal Server Error'))
+      .mockRejectedValue(networkError('ECONNREFUSED'));
+    await expect(
+      fetchWithRetry(URL, { fetchImpl, sleep: instantSleep, log: silentLog }),
+    ).rejects.toThrow(
+      `Config API unreachable after ${MAX_ATTEMPTS} attempts (ECONNREFUSED: network trouble)`,
+    );
+  });
+
+  it('caps total backoff at ~30s across attempts', () => {
+    const total = RETRY_DELAYS_MS.reduce((a, b) => a + b, 0);
+    expect(total).toBeLessThanOrEqual(35000);
+    expect(MAX_ATTEMPTS).toBe(5);
+  });
+});

--- a/packages/closer/scripts/__tests__/syncBuildConfig.test.js
+++ b/packages/closer/scripts/__tests__/syncBuildConfig.test.js
@@ -1,5 +1,6 @@
 const {
   fetchWithRetry,
+  resolveConfigApiUrl,
   MAX_ATTEMPTS,
   RETRY_DELAYS_MS,
 } = require('../syncBuildConfig.cjs');
@@ -91,13 +92,37 @@ describe('fetchWithRetry', () => {
   it('reports the HTTP status when every attempt gets a non-200', async () => {
     const fetchImpl = jest
       .fn()
-      .mockResolvedValue(errorResponse(502, 'Bad Gateway', 'upstream down'));
+      .mockResolvedValue(
+        errorResponse(502, 'Bad Gateway', 'secret upstream detail'),
+      );
     await expect(
       fetchWithRetry(URL, { fetchImpl, sleep: instantSleep, log: silentLog }),
     ).rejects.toThrow(
-      `Config request failed after ${MAX_ATTEMPTS} attempts: HTTP 502 Bad Gateway`,
+      `Config request failed after ${MAX_ATTEMPTS} attempts: HTTP 502 Bad Gateway. URL: ${URL}`,
     );
     expect(fetchImpl).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+  });
+
+  it('never includes the response body in the thrown error or logs', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(
+        errorResponse(500, 'Internal Server Error', 'db password leaked'),
+      );
+    let thrown;
+    try {
+      await fetchWithRetry(URL, {
+        fetchImpl,
+        sleep: instantSleep,
+        log: silentLog,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown.message).not.toContain('db password leaked');
+    for (const [msg] of silentLog.warn.mock.calls) {
+      expect(msg).not.toContain('db password leaked');
+    }
   });
 
   it('classifies the failure by the last attempt (network error after HTTP errors)', async () => {
@@ -116,5 +141,46 @@ describe('fetchWithRetry', () => {
     const total = RETRY_DELAYS_MS.reduce((a, b) => a + b, 0);
     expect(total).toBeLessThanOrEqual(35000);
     expect(MAX_ATTEMPTS).toBe(5);
+  });
+});
+
+describe('resolveConfigApiUrl', () => {
+  it('prefers CONFIG_BUILD_API_URL over NEXT_PUBLIC_API_URL', () => {
+    expect(
+      resolveConfigApiUrl({
+        CONFIG_BUILD_API_URL: 'https://app.ondigitalocean.app',
+        NEXT_PUBLIC_API_URL: 'https://api.example.closer.earth',
+      }),
+    ).toEqual({ apiUrl: 'https://app.ondigitalocean.app', isOverride: true });
+  });
+
+  it('falls back to NEXT_PUBLIC_API_URL when no override is set', () => {
+    expect(
+      resolveConfigApiUrl({
+        NEXT_PUBLIC_API_URL: 'https://api.example.closer.earth',
+      }),
+    ).toEqual({
+      apiUrl: 'https://api.example.closer.earth',
+      isOverride: false,
+    });
+  });
+
+  it('returns null when neither variable is set', () => {
+    expect(resolveConfigApiUrl({})).toEqual({
+      apiUrl: null,
+      isOverride: false,
+    });
+  });
+
+  it('ignores an empty-string override', () => {
+    expect(
+      resolveConfigApiUrl({
+        CONFIG_BUILD_API_URL: '',
+        NEXT_PUBLIC_API_URL: 'https://api.example.closer.earth',
+      }),
+    ).toEqual({
+      apiUrl: 'https://api.example.closer.earth',
+      isOverride: false,
+    });
   });
 });

--- a/packages/closer/scripts/syncBuildConfig.cjs
+++ b/packages/closer/scripts/syncBuildConfig.cjs
@@ -213,6 +213,7 @@ module.exports = {
   configPayloadToSlugMap,
   fetchWithRetry,
   resolveConfigApiUrl,
+  FETCH_TIMEOUT_MS,
   MAX_ATTEMPTS,
   RETRY_DELAYS_MS,
 };

--- a/packages/closer/scripts/syncBuildConfig.cjs
+++ b/packages/closer/scripts/syncBuildConfig.cjs
@@ -120,19 +120,8 @@ async function fetchWithRetry(
 
     if (res) {
       if (res.ok) return res;
-      let bodyHint = '';
-      try {
-        const text = await res.text();
-        if (text) bodyHint = ` Response: ${text.slice(0, 500)}`;
-      } catch {
-        /* ignore */
-      }
       lastNetworkDetail = null;
-      lastHttpFailure = {
-        status: res.status,
-        statusText: res.statusText,
-        bodyHint,
-      };
+      lastHttpFailure = { status: res.status, statusText: res.statusText };
       log.warn(
         `[sync-build-config] Attempt ${attempt}/${MAX_ATTEMPTS} got HTTP ${res.status} ${res.statusText}. URL: ${url}`,
       );
@@ -147,7 +136,7 @@ async function fetchWithRetry(
 
   if (lastHttpFailure) {
     throw new Error(
-      `Config request failed after ${MAX_ATTEMPTS} attempts: HTTP ${lastHttpFailure.status} ${lastHttpFailure.statusText}. URL: ${url}.${lastHttpFailure.bodyHint}`,
+      `Config request failed after ${MAX_ATTEMPTS} attempts: HTTP ${lastHttpFailure.status} ${lastHttpFailure.statusText}. URL: ${url}`,
     );
   }
   throw new Error(
@@ -155,20 +144,30 @@ async function fetchWithRetry(
   );
 }
 
+/**
+ * Pick the API base URL for the build-time config fetch:
+ * CONFIG_BUILD_API_URL wins over NEXT_PUBLIC_API_URL; null when neither is
+ * set. Returns { apiUrl, isOverride }.
+ */
+function resolveConfigApiUrl(env) {
+  const overrideUrl = env.CONFIG_BUILD_API_URL;
+  const apiUrl = overrideUrl || env.NEXT_PUBLIC_API_URL || null;
+  return { apiUrl, isOverride: Boolean(overrideUrl) };
+}
+
 async function main() {
   const packageRoot = path.join(__dirname, '..');
   loadEnvFromDir(packageRoot);
   loadEnvFromDir(process.cwd(), { override: true });
 
-  const overrideUrl = process.env.CONFIG_BUILD_API_URL;
-  const apiUrl = overrideUrl || process.env.NEXT_PUBLIC_API_URL;
+  const { apiUrl, isOverride } = resolveConfigApiUrl(process.env);
   if (!apiUrl) {
     console.warn(
       '[sync-build-config] Neither CONFIG_BUILD_API_URL nor NEXT_PUBLIC_API_URL is set; keeping existing snapshot.',
     );
     process.exit(0);
   }
-  if (overrideUrl) {
+  if (isOverride) {
     console.log(
       '[sync-build-config] Using CONFIG_BUILD_API_URL override instead of NEXT_PUBLIC_API_URL.',
     );
@@ -213,6 +212,7 @@ if (require.main === module) {
 module.exports = {
   configPayloadToSlugMap,
   fetchWithRetry,
+  resolveConfigApiUrl,
   MAX_ATTEMPTS,
   RETRY_DELAYS_MS,
 };

--- a/packages/closer/scripts/syncBuildConfig.cjs
+++ b/packages/closer/scripts/syncBuildConfig.cjs
@@ -1,9 +1,32 @@
+/**
+ * sync-build-config
+ *
+ * Fetches the platform config from the API at build time and writes it to
+ * generated/appConfig.snapshot.json.
+ *
+ * Environment variables:
+ * - CONFIG_BUILD_API_URL: optional override for the API base URL used ONLY by
+ *   this build-time fetch. When set, config is fetched from
+ *   `<CONFIG_BUILD_API_URL>/config?limit=500` instead of NEXT_PUBLIC_API_URL.
+ *   Provisioning sets this to the app's default ingress hostname
+ *   (e.g. https://<app>.ondigitalocean.app), which is immune to the DNS
+ *   churn a freshly provisioned custom domain goes through.
+ * - NEXT_PUBLIC_API_URL: the default API base URL (also used at runtime).
+ *
+ * The fetch is retried with exponential backoff (see RETRY_DELAYS_MS) on both
+ * network-level errors and non-200 responses, because Vercel build containers
+ * have transiently failed to resolve/route to freshly provisioned domains.
+ */
 require('./ensureBuildConfigSnapshotExists.cjs');
 
 const fs = require('fs');
 const path = require('path');
 
 const OUT = path.join(__dirname, '..', 'generated', 'appConfig.snapshot.json');
+
+const FETCH_TIMEOUT_MS = 20000;
+const RETRY_DELAYS_MS = [2000, 4000, 8000, 16000];
+const MAX_ATTEMPTS = RETRY_DELAYS_MS.length + 1;
 
 function configPayloadToSlugMap(data) {
   const results = Array.isArray(data?.results) ? data.results : [];
@@ -43,65 +66,123 @@ function loadEnvFromDir(dir, { override = false } = {}) {
   }
 }
 
+function describeFetchError(err) {
+  const cause = err.cause;
+  let detail = err.message || 'unknown error';
+  if (cause && typeof cause === 'object') {
+    if (cause.code) {
+      detail = `${cause.code}${cause.message ? `: ${cause.message}` : ''}`;
+    } else if (Array.isArray(cause.errors) && cause.errors.length > 0) {
+      const first = cause.errors[0];
+      detail =
+        first && typeof first === 'object' && first.code
+          ? `${first.code}${first.message ? `: ${first.message}` : ''}`
+          : detail;
+    }
+  }
+  if (err && err.name === 'AbortError') {
+    detail = `timed out after ${FETCH_TIMEOUT_MS}ms`;
+  }
+  return detail;
+}
+
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Fetch `url` with bounded retries. Retries on network-level errors AND
+ * non-200 responses, backing off per RETRY_DELAYS_MS between attempts.
+ * Resolves with the ok Response; rejects with an Error whose message
+ * distinguishes "unreachable after N attempts" (network) from
+ * "HTTP <status>" (server responded, never ok).
+ */
+async function fetchWithRetry(
+  url,
+  { fetchImpl = fetch, sleep = defaultSleep, log = console } = {},
+) {
+  let lastNetworkDetail = null;
+  let lastHttpFailure = null;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    let res;
+    try {
+      res = await fetchImpl(url, { signal: controller.signal });
+    } catch (err) {
+      lastNetworkDetail = describeFetchError(err);
+      lastHttpFailure = null;
+      log.warn(
+        `[sync-build-config] Attempt ${attempt}/${MAX_ATTEMPTS} failed (${lastNetworkDetail}). URL: ${url}`,
+      );
+      res = null;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (res) {
+      if (res.ok) return res;
+      let bodyHint = '';
+      try {
+        const text = await res.text();
+        if (text) bodyHint = ` Response: ${text.slice(0, 500)}`;
+      } catch {
+        /* ignore */
+      }
+      lastNetworkDetail = null;
+      lastHttpFailure = {
+        status: res.status,
+        statusText: res.statusText,
+        bodyHint,
+      };
+      log.warn(
+        `[sync-build-config] Attempt ${attempt}/${MAX_ATTEMPTS} got HTTP ${res.status} ${res.statusText}. URL: ${url}`,
+      );
+    }
+
+    if (attempt < MAX_ATTEMPTS) {
+      const delay = RETRY_DELAYS_MS[attempt - 1];
+      log.warn(`[sync-build-config] Retrying in ${delay / 1000}s...`);
+      await sleep(delay);
+    }
+  }
+
+  if (lastHttpFailure) {
+    throw new Error(
+      `Config request failed after ${MAX_ATTEMPTS} attempts: HTTP ${lastHttpFailure.status} ${lastHttpFailure.statusText}. URL: ${url}.${lastHttpFailure.bodyHint}`,
+    );
+  }
+  throw new Error(
+    `Config API unreachable after ${MAX_ATTEMPTS} attempts (${lastNetworkDetail}). URL: ${url}`,
+  );
+}
+
 async function main() {
   const packageRoot = path.join(__dirname, '..');
   loadEnvFromDir(packageRoot);
   loadEnvFromDir(process.cwd(), { override: true });
 
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  const overrideUrl = process.env.CONFIG_BUILD_API_URL;
+  const apiUrl = overrideUrl || process.env.NEXT_PUBLIC_API_URL;
   if (!apiUrl) {
     console.warn(
-      '[sync-build-config] NEXT_PUBLIC_API_URL is not set; keeping existing snapshot.',
+      '[sync-build-config] Neither CONFIG_BUILD_API_URL nor NEXT_PUBLIC_API_URL is set; keeping existing snapshot.',
     );
     process.exit(0);
+  }
+  if (overrideUrl) {
+    console.log(
+      '[sync-build-config] Using CONFIG_BUILD_API_URL override instead of NEXT_PUBLIC_API_URL.',
+    );
   }
 
   const base = apiUrl.replace(/\/$/, '');
   const url = `${base}/config?limit=500`;
-  const FETCH_TIMEOUT_MS = 20000;
   console.log('[sync-build-config] fetching', url);
-
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
   let res;
   try {
-    res = await fetch(url, { signal: controller.signal });
+    res = await fetchWithRetry(url);
   } catch (err) {
-    const cause = err.cause;
-    let detail = err.message || 'unknown error';
-    if (cause && typeof cause === 'object') {
-      if (cause.code) detail = `${cause.code}${cause.message ? `: ${cause.message}` : ''}`;
-      else if (Array.isArray(cause.errors) && cause.errors.length > 0) {
-        const first = cause.errors[0];
-        detail =
-          first && typeof first === 'object' && first.code
-            ? `${first.code}${first.message ? `: ${first.message}` : ''}`
-            : detail;
-      }
-    }
-    if (err && err.name === 'AbortError') {
-      detail = `timed out after ${FETCH_TIMEOUT_MS}ms`;
-    }
-    console.error(
-      `[sync-build-config] Failed to fetch config (${detail}). URL: ${url}`,
-    );
-    process.exit(1);
-  } finally {
-    clearTimeout(timeoutId);
-  }
-
-  if (!res.ok) {
-    let bodyHint = '';
-    try {
-      const text = await res.text();
-      if (text) bodyHint = ` Response: ${text.slice(0, 500)}`;
-    } catch {
-      /* ignore */
-    }
-    console.error(
-      `[sync-build-config] Config request failed: ${res.status} ${res.statusText}. URL: ${url}.${bodyHint}`,
-    );
+    console.error(`[sync-build-config] ${err.message}`);
     process.exit(1);
   }
 
@@ -120,9 +201,18 @@ async function main() {
   console.log('[sync-build-config] wrote', OUT);
 }
 
-main().catch((err) => {
-  console.error(
-    `[sync-build-config] Unexpected error: ${err && err.message ? err.message : String(err)}`,
-  );
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(
+      `[sync-build-config] Unexpected error: ${err && err.message ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  configPayloadToSlugMap,
+  fetchWithRetry,
+  MAX_ATTEMPTS,
+  RETRY_DELAYS_MS,
+};


### PR DESCRIPTION
Closes #941

## Why

Two production Vercel builds for a freshly provisioned village app died tonight, 12 minutes apart, from different build containers, with:

```
[sync-build-config] Failed to fetch config (ENETUNREACH). URL: https://api.<slug>.closer.earth/config?limit=500
```

`packages/closer/scripts/syncBuildConfig.cjs` made a single, unretried fetch against the custom domain, whose DNS was still churning right after provisioning (and the repeat across containers suggests IPv6/route issues in Vercel builders rather than one-off flake).

## What

1. **`CONFIG_BUILD_API_URL` override (documented in the script header):** when set, the build-time config fetch uses `<CONFIG_BUILD_API_URL>/config?limit=500` instead of `NEXT_PUBLIC_API_URL`. The override replaces the URL; retries apply to whichever URL is in use.
2. **Bounded retry with backoff** regardless of URL source: 5 attempts, 2/4/8/16s backoff (~30s total), retrying on network-level errors AND non-200 responses. The final error distinguishes `Config API unreachable after 5 attempts (<code>)` from `Config request failed after 5 attempts: HTTP <status>`.

## Companion (procurement side)

The provisioning workflow in closer-procurement will set `CONFIG_BUILD_API_URL` on the Vercel project to the village API's DigitalOcean app default ingress (`https://<app>.ondigitalocean.app`) — a hostname that exists and resolves the moment the app is provisioned, immune to custom-domain DNS churn.

## Verification

- New jest tests (`packages/closer/scripts/__tests__/syncBuildConfig.test.js`, injected fetch/sleep): 7 passing — first-try success, retry-then-success on network errors and on non-200s, backoff sequence 2/4/8/16s, and error classification (unreachable vs HTTP status) by last attempt.
- Ran the script against a local mock server returning 503 twice then 200, with `CONFIG_BUILD_API_URL` set: override honored, two retries logged, snapshot written, exit 0.

https://claude.ai/code/session_01YCx29dRM7c7zU22gCAUHhE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the build-time API URL.
  * Added automatic retries for network failures and unsuccessful API responses.
  * Improved error messages with timeout details, HTTP status, and response context.
  * Preserves the existing configuration snapshot when no API URL is provided.

* **Tests**
  * Added coverage for successful requests, retries, backoff behavior, failure handling, and retry limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->