### PR TITLE
fix(sync-build-config): redact URL userinfo from build logs and errors

### DIFF
--- a/packages/closer/scripts/__tests__/syncBuildConfig.test.js
+++ b/packages/closer/scripts/__tests__/syncBuildConfig.test.js
@@ -1,5 +1,6 @@
 const {
   fetchWithRetry,
+  redactUrl,
   resolveConfigApiUrl,
   FETCH_TIMEOUT_MS,
   MAX_ATTEMPTS,
@@ -181,6 +182,69 @@ describe('fetchWithRetry', () => {
     const total = RETRY_DELAYS_MS.reduce((a, b) => a + b, 0);
     expect(total).toBeLessThanOrEqual(35000);
     expect(MAX_ATTEMPTS).toBe(5);
+  });
+});
+
+describe('redactUrl', () => {
+  it('strips userinfo credentials from a URL', () => {
+    expect(redactUrl('https://user:s3cret@api.example.com/config?limit=500')).toBe(
+      'https://api.example.com/config?limit=500',
+    );
+  });
+
+  it('leaves credential-free URLs unchanged', () => {
+    expect(redactUrl(URL)).toBe(URL);
+  });
+
+  it('strips userinfo even from unparseable URL-like strings', () => {
+    expect(redactUrl('notaurl//user:pass@host/path')).not.toContain('s3cret');
+    expect(redactUrl('http://user:pass@[bad')).not.toContain('pass');
+  });
+});
+
+describe('fetchWithRetry URL redaction', () => {
+  const CRED_URL = 'https://builder:s3cret@api.example.com/config?limit=500';
+
+  it('never emits URL credentials in warnings or the thrown error', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockRejectedValue(networkError('ENETUNREACH'));
+    let thrown;
+    try {
+      await fetchWithRetry(CRED_URL, {
+        fetchImpl,
+        sleep: instantSleep,
+        log: silentLog,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown.message).not.toContain('s3cret');
+    expect(thrown.message).not.toContain('builder:');
+    for (const [msg] of silentLog.warn.mock.calls) {
+      expect(msg).not.toContain('s3cret');
+    }
+    expect(fetchImpl).toHaveBeenCalledWith(CRED_URL, expect.anything());
+  });
+
+  it('never emits URL credentials on HTTP-failure exhaustion', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(errorResponse(502, 'Bad Gateway'));
+    let thrown;
+    try {
+      await fetchWithRetry(CRED_URL, {
+        fetchImpl,
+        sleep: instantSleep,
+        log: silentLog,
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown.message).not.toContain('s3cret');
+    for (const [msg] of silentLog.warn.mock.calls) {
+      expect(msg).not.toContain('s3cret');
+    }
   });
 });
 

--- a/packages/closer/scripts/syncBuildConfig.cjs
+++ b/packages/closer/scripts/syncBuildConfig.cjs
@@ -86,6 +86,22 @@ function describeFetchError(err) {
   return detail;
 }
 
+/**
+ * Strip userinfo (user:pass@) from a URL before logging so credentials
+ * embedded in CONFIG_BUILD_API_URL / NEXT_PUBLIC_API_URL never reach
+ * build logs or error output.
+ */
+function redactUrl(url) {
+  try {
+    const parsed = new URL(url);
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.toString();
+  } catch {
+    return String(url).replace(/\/\/[^@/]*@/, '//');
+  }
+}
+
 const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
@@ -111,7 +127,7 @@ async function fetchWithRetry(
       lastNetworkDetail = describeFetchError(err);
       lastHttpFailure = null;
       log.warn(
-        `[sync-build-config] Attempt ${attempt}/${MAX_ATTEMPTS} failed (${lastNetworkDetail}). URL: ${url}`,
+        `[sync-build-config] Attempt ${attempt}/${MAX_ATTEMPTS} failed (${lastNetworkDetail}). URL: ${redactUrl(url)}`,
       );
       res = null;
     } finally {
@@ -123,7 +139,7 @@ async function fetchWithRetry(
       lastNetworkDetail = null;
       lastHttpFailure = { status: res.status, statusText: res.statusText };
       log.warn(
-        `[sync-build-config] Attempt ${attempt}/${MAX_ATTEMPTS} got HTTP ${res.status} ${res.statusText}. URL: ${url}`,
+        `[sync-build-config] Attempt ${attempt}/${MAX_ATTEMPTS} got HTTP ${res.status} ${res.statusText}. URL: ${redactUrl(url)}`,
       );
     }
 
@@ -136,11 +152,11 @@ async function fetchWithRetry(
 
   if (lastHttpFailure) {
     throw new Error(
-      `Config request failed after ${MAX_ATTEMPTS} attempts: HTTP ${lastHttpFailure.status} ${lastHttpFailure.statusText}. URL: ${url}`,
+      `Config request failed after ${MAX_ATTEMPTS} attempts: HTTP ${lastHttpFailure.status} ${lastHttpFailure.statusText}. URL: ${redactUrl(url)}`,
     );
   }
   throw new Error(
-    `Config API unreachable after ${MAX_ATTEMPTS} attempts (${lastNetworkDetail}). URL: ${url}`,
+    `Config API unreachable after ${MAX_ATTEMPTS} attempts (${lastNetworkDetail}). URL: ${redactUrl(url)}`,
   );
 }
 
@@ -175,7 +191,7 @@ async function main() {
 
   const base = apiUrl.replace(/\/$/, '');
   const url = `${base}/config?limit=500`;
-  console.log('[sync-build-config] fetching', url);
+  console.log('[sync-build-config] fetching', redactUrl(url));
 
   let res;
   try {
@@ -190,7 +206,7 @@ async function main() {
     data = await res.json();
   } catch (err) {
     console.error(
-      `[sync-build-config] Config response was not valid JSON. URL: ${url}. ${err.message}`,
+      `[sync-build-config] Config response was not valid JSON. URL: ${redactUrl(url)}. ${err.message}`,
     );
     process.exit(1);
   }
@@ -212,6 +228,7 @@ if (require.main === module) {
 module.exports = {
   configPayloadToSlugMap,
   fetchWithRetry,
+  redactUrl,
   resolveConfigApiUrl,
   FETCH_TIMEOUT_MS,
   MAX_ATTEMPTS,


### PR DESCRIPTION
Addresses the Cursor security MEDIUM raised on #943: the config-fetch retry/error paths log the full request URL, which would leak credentials into build/CI logs if `CONFIG_BUILD_API_URL` or `NEXT_PUBLIC_API_URL` were ever set as `https://user:pass@host`.

## Changes
- New `redactUrl()` strips userinfo (`user:pass@`) from any URL before it reaches logs or thrown errors — covers all retry warnings, both exhaustion errors, the invalid-JSON error, and the happy-path `fetching` line. Falls back to a regex strip for unparseable URL-like strings.
- Exported for tests; 5 new regression tests (19/19 passing) assert credentials never appear in warnings or thrown errors while the real fetch still receives the unredacted URL.

After merge, develop→main promotion #943 picks this up.

https://claude.ai/code/session_01YCx29dRM7c7zU22gCAUHhE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by removing embedded URL credentials from warning messages and errors.
  * Preserved full URLs for requests while ensuring credentials are not exposed during retries, HTTP failures, or invalid responses.
  * Added handling for malformed URL-like strings to prevent accidental credential disclosure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->