### PR TITLE
fix(build): declare CONFIG_BUILD_API_URL in turbo build:config env

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
     "build:config": {
       "inputs": ["scripts/syncBuildConfig.cjs", "scripts/ensureBuildConfigSnapshotExists.cjs"],
       "outputs": ["generated/appConfig.snapshot.json"],
-      "env": ["NEXT_PUBLIC_API_URL"]
+      "env": ["NEXT_PUBLIC_API_URL", "CONFIG_BUILD_API_URL"]
     },
     "build": {
       "dependsOn": ["^build", "^build:locales", "^build:config"],


### PR DESCRIPTION
Live lifecycle e2e caught this on village reactivate: provisioning pushed `CONFIG_BUILD_API_URL` to the Vercel project env (confirmed in the provisioning JSONL), yet the build's `[sync-build-config]` still fetched the custom domain and died on ENETUNREACH×5 — the domain had been repointed 4 minutes earlier and was inside the DO NS propagation window, precisely the situation the override exists for.

Root cause: `build:config` in `turbo.json` only declares `NEXT_PUBLIC_API_URL`, and turbo strict env mode strips undeclared vars before the task runs. The earlier site-build success was DNS luck masking the gap.

One-line fix: declare `CONFIG_BUILD_API_URL` in the task's `env`. Side benefit: the turbo cache key now varies with the override, so a cached snapshot can't be replayed across different config sources.

https://claude.ai/code/session_01YCx29dRM7c7zU22gCAUHhE