### PR TITLE
chore: promote develop to main (turbo CONFIG_BUILD_API_URL env fix)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,7 @@
     "build:config": {
       "inputs": ["scripts/syncBuildConfig.cjs", "scripts/ensureBuildConfigSnapshotExists.cjs"],
       "outputs": ["generated/appConfig.snapshot.json"],
-      "env": ["NEXT_PUBLIC_API_URL"]
+      "env": ["NEXT_PUBLIC_API_URL", "CONFIG_BUILD_API_URL"]
     },
     "build": {
       "dependsOn": ["^build", "^build:locales", "^build:config"],


### PR DESCRIPTION
Promotes the #957 one-liner: declare `CONFIG_BUILD_API_URL` in `build:config`'s turbo env so strict mode stops stripping the provisioning override before sync-build-config runs. Needed on main because village Vercel builds compile main.

https://claude.ai/code/session_01YCx29dRM7c7zU22gCAUHhE