### PR TITLE
fix(build): declare CONFIG_BUILD_API_URL in turbo build env too (completes #957)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,7 @@
       "env": [
         "NEXT_PUBLIC_CDN_URL",
         "NEXT_PUBLIC_API_URL",
+        "CONFIG_BUILD_API_URL",
         "NEXT_PUBLIC_PLATFORM",
         "NEXT_PUBLIC_PLATFORM_URL",
         "NEXT_PUBLIC_LOG_REQUESTS",


### PR DESCRIPTION
#957 was the right fix in the wrong place — or rather, in only one of the two places.

## What #957 missed

`sync-build-config` runs **twice** in a Vercel build. Once as the `closer#build:config` turbo task (which #957 fixed), and again inside every app's `build` task, because each app's `package.json` has:

```json
"prebuild": "node ../../packages/closer/scripts/syncBuildLocales.cjs && node ../../packages/closer/scripts/syncBuildConfig.cjs"
```

`prebuild` is an npm/yarn lifecycle hook, so it fires whenever turbo runs `build` — and `build` in `turbo.json` did **not** declare `CONFIG_BUILD_API_URL`. Turbo strict env mode stripped it there, the second run fell back to `NEXT_PUBLIC_API_URL` (the branded custom domain), and its snapshot **overwrote** the correct one that `build:config` had just written to `packages/closer/generated/appConfig.snapshot.json`.

Net effect: #957's fix was cosmetic on the real deploy path. The snapshot that actually ships is the one the `build` task wrote.

## Evidence from production

Vercel build at `main` @ `7bd90acf` (deployment `dpl_BqyRJStnfwX3dFqPU5WLhBNGFcWg`), with `CONFIG_BUILD_API_URL` correctly set in the project env:

```
closer:build:config: [sync-build-config] Using CONFIG_BUILD_API_URL override instead of NEXT_PUBLIC_API_URL.
closer:build:config: [sync-build-config] fetching https://closer-v2-api-e2e-avi-2-58val.ondigitalocean.app/config?limit=500   <- correct, ingress
village-app:build:   [sync-build-config] fetching https://api.e2e-avi-2.closer.earth/config?limit=500                        <- wrong, branded domain
[warn] village-app#build
[warn]   - CONFIG_BUILD_API_URL
```

Turbo names the undeclared variable itself in that warning.

This is not theoretical. Deployment `dpl_FKc4…` (the #957 branch build) **failed** with `ENETUNREACH` fetching `https://api.e2e-avi-2.closer.earth/config` from exactly this task. It only stops failing once the village's custom domain has propagated — so **freshly provisioned villages break during procurement provisioning**, which is precisely the window the override exists to serve.

## The change

One line: `CONFIG_BUILD_API_URL` added to the `build` task's `env` array, next to `NEXT_PUBLIC_API_URL`, matching how #957 did it for `build:config`. Because `build` is a single shared task definition, this covers all eight apps (`closer`, `village-app`, `tdf`, `foz`, `lios`, `earthbound`, `moos`, `per-auset`) at once. It also keys each app's turbo cache on the override, so a snapshot fetched from one config source can't be replayed for another.

## Scope check

I traced every invocation of `syncBuildConfig.cjs` rather than assuming. It is reached from exactly two turbo tasks:

| Task | Path | Before | After |
|---|---|---|---|
| `closer#build:config` | root `build:config` script | declared (#957) | declared |
| `<app>#build` (×8) | app `prebuild` hook | **stripped** | declared |

`build:locales` is **not** affected — `syncBuildLocales.cjs` only requires `ensureBuildLocalesExist.cjs` and touches no API URL. Confirmed by `turbo run build:locales --filter=closer`, which emits no `[sync-build-config]` line. `lint`, `test`, `dev` do not run it on any build path either. No other task's `env` list is touched.

## Verification

Ran real builds against two local stub config servers on distinct ports so the fetched host is unambiguous: `:4311` stands in for the branded domain (`NEXT_PUBLIC_API_URL`), `:4312` for the ingress override (`CONFIG_BUILD_API_URL`).

**Before (this branch's merge-base, `develop` @ `ceafedd5`)** — `turbo run build --filter=village-app --force`:

```
closer:build:config: [sync-build-config] Using CONFIG_BUILD_API_URL override instead of NEXT_PUBLIC_API_URL.
closer:build:config: [sync-build-config] fetching http://localhost:4312/config?limit=500
closer:build:config: [sync-build-config] wrote .../generated/appConfig.snapshot.json
village-app:build: [sync-build-config] fetching http://localhost:4311/config?limit=500        <- bug reproduced
village-app:build: [sync-build-config] wrote .../generated/appConfig.snapshot.json            <- clobbers the correct snapshot
```

**After**, same command:

```
closer:build:config: [sync-build-config] Using CONFIG_BUILD_API_URL override instead of NEXT_PUBLIC_API_URL.
closer:build:config: [sync-build-config] fetching http://localhost:4312/config?limit=500
village-app:build: [sync-build-config] Using CONFIG_BUILD_API_URL override instead of NEXT_PUBLIC_API_URL.
village-app:build: [sync-build-config] fetching http://localhost:4312/config?limit=500
 Tasks:    3 successful, 3 total
```

**`apps/closer` with the override** — `turbo run build --filter=closer-app --force`:

```
closer:build:config:  [sync-build-config] fetching http://localhost:4312/config?limit=500
closer-app:build:     [sync-build-config] Using CONFIG_BUILD_API_URL override instead of NEXT_PUBLIC_API_URL.
closer-app:build:     [sync-build-config] fetching http://localhost:4312/config?limit=500
 Tasks:    3 successful, 3 total
```

**Fallback intact — `village-app` with `CONFIG_BUILD_API_URL` unset:**

```
closer:build:config:  [sync-build-config] fetching http://localhost:4311/config?limit=500
village-app:build:    [sync-build-config] fetching http://localhost:4311/config?limit=500
 Tasks:    3 successful, 3 total
```

No `Using CONFIG_BUILD_API_URL override` line, both paths correctly on `NEXT_PUBLIC_API_URL`. All four runs completed a full Next.js production build successfully.

Refs #957, #902.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to recognize the `CONFIG_BUILD_API_URL` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->