### PR TITLE
chore: promote develop to main (CONFIG_BUILD_API_URL in turbo build env)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,7 @@
       "env": [
         "NEXT_PUBLIC_CDN_URL",
         "NEXT_PUBLIC_API_URL",
+        "CONFIG_BUILD_API_URL",
         "NEXT_PUBLIC_PLATFORM",
         "NEXT_PUBLIC_PLATFORM_URL",
         "NEXT_PUBLIC_LOG_REQUESTS",


### PR DESCRIPTION
Promotes #960 to `main`.

## Why now

#957 declared `CONFIG_BUILD_API_URL` on `build:config` only. Every app's `prebuild` hook also runs `syncBuildConfig.cjs`, and that run happens **after** `closer#build:config` and writes the same file — so `<app>#build` was overwriting the correct snapshot with one fetched from the branded domain. #957 was cosmetic on the real deploy path.

## Proven blocking

A live e2e lifecycle run on `e2e-avi-2` fails its **reactivate** leg on exactly this:

```
village-app:build: [sync-build-config] fetching https://api.e2e-avi-2.closer.earth/config?limit=500
village-app:build: [sync-build-config] Attempt 1..5/5 failed (ENETUNREACH)
 ERROR  village-app#build: ... exited (1)
[warn] village-app#build
[warn]   - CONFIG_BUILD_API_URL
```

Reactivation creates a new DO app with a new ingress and repoints the branded domain at it, so the builder always meets a just-changed DNS record. This is systematic on reactivate, not a race — the leg cannot pass until this lands.

Verified before/after with real production builds against two stub config servers on distinct ports; the fallback path with the override unset is unchanged.